### PR TITLE
Add neutering for cardValidationNum 

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 = Vantiv eCommerce CNP CHANGELOG
 
+==Version 12.11.2 (March 23, 2020)
+* BugFix: Add neutering for cardValidationNum
+
 ==Version 12.11.1 (February 11, 2020)
 * BugFix: Neutering of XMLRequest for log was affecting actual log, separated these two XMLs.
 

--- a/src/main/java/com/cnp/sdk/Communication.java
+++ b/src/main/java/com/cnp/sdk/Communication.java
@@ -333,6 +333,7 @@ public class Communication {
 		xml = xml.replaceAll("<password>.*</password>", "<password>" + NEUTER_STR + "</password>");
 		xml = xml.replaceAll("<track>.*</track>", "<track>" + NEUTER_STR + "</track>");
 		xml = xml.replaceAll("<number>.*</number>", "<number>" + NEUTER_STR + "</number>");
+		xml = xml.replaceAll("<cardValidationNum>.*</cardValidationNum>", "<cardValidationNum>" + NEUTER_STR + "</cardValidationNum>");
 		return xml;
 	}
 

--- a/src/main/java/com/cnp/sdk/Versions.java
+++ b/src/main/java/com/cnp/sdk/Versions.java
@@ -3,6 +3,6 @@ package com.cnp.sdk;
 public class Versions {
 
     public static final String XML_VERSION="12.11";
-    public static final String SDK_VERSION="Java;12.11.1";
+    public static final String SDK_VERSION="Java;12.11.2";
 
 }

--- a/src/test/java/com/cnp/sdk/TestCommunication.java
+++ b/src/test/java/com/cnp/sdk/TestCommunication.java
@@ -52,6 +52,7 @@ public class TestCommunication {
 				"<number>4100000000000000</number>" +
 				"<track>dummy track data</track>" +
 				"<expDate>1210</expDate>" +
+				"<cardValidationNum>1234</cardValidationNum>" +
 				"</card>" +
 				"<echeck>" +
 				"<accType>Checking</accType>" +
@@ -74,6 +75,7 @@ public class TestCommunication {
 				"<number>NEUTERED</number>" +
 				"<track>NEUTERED</track>" +
 				"<expDate>1210</expDate>" +
+				"<cardValidationNum>NEUTERED</cardValidationNum>" +
 				"</card>" +
 				"<echeck>" +
 				"<accType>Checking</accType>" +


### PR DESCRIPTION
Goal of this change is to add XML neutering for cardValidationNum. This was promised back in LitleSDK but we neglected to add it, so this change will be treated as a bugfix. 