### PR TITLE
12.18 Upgrade

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,7 @@
 = Vantiv eCommerce CNP CHANGELOG
 
 ==Version 12.18.0 (November 30, 2020)
-* Feature: Added support for strings up to 64 characters in length for transaction types
+* Feature: Added support for orderId to be up to 64 characters in length (for transaction types)
 
 ==Version 12.17.1 (November 25, 2020)
 * Change: Rewrote part of ResponseFileParser to reduce the potential for future bugs

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 = Vantiv eCommerce CNP CHANGELOG
 
+==Version 12.18.0 (November 30, 2020)
+* Feature: Added support for strings up to 64 characters in length for transaction types
+
 ==Version 12.17.1 (November 25, 2020)
 * Change: Rewrote part of ResponseFileParser to reduce the potential for future bugs
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 DIST_DIR_15=build/dist/java15
-JAR_VERSION=12.17.1
+JAR_VERSION=12.18.0
 KIT_DIR=build/kit/java15
 KIT_DEPENDENCIES_DIR=build/kit/java15/dependencies
 OPENSFTP_DIR=lib/opensftp-0.3.0
-SCHEMA_VERSION=12.17
+SCHEMA_VERSION=12.18

--- a/src/functionalTest/java/com/cnp/sdk/TestGiftCardTransactions.java
+++ b/src/functionalTest/java/com/cnp/sdk/TestGiftCardTransactions.java
@@ -89,7 +89,7 @@ public class TestGiftCardTransactions {
         gcCredit.setCustomerId("customer_22");
         gcCredit.setOrderSource(OrderSourceType.ECOMMERCE);
         gcCredit.setCreditAmount(1942l);
-        gcCredit.setOrderId("order 4");
+        gcCredit.setOrderId("order 4 with a really long order id");
         gcCredit.setCard(giftCard);
         
         GiftCardCreditResponse response = cnp.giftCardCredit(gcCredit);
@@ -97,7 +97,7 @@ public class TestGiftCardTransactions {
         assertEquals("123456", response.getGiftCardResponse().getSequenceNumber());
         assertEquals("sandbox", response.getLocation());
 	}
-	
+
 	@Test
 	public void testGiftCardAuthReversal() {
 		GiftCardAuthReversal gcAuthReversal = new GiftCardAuthReversal();

--- a/src/main/java/com/cnp/sdk/Versions.java
+++ b/src/main/java/com/cnp/sdk/Versions.java
@@ -2,7 +2,7 @@ package com.cnp.sdk;
 
 public class Versions {
 
-    public static final String XML_VERSION="12.17";
-    public static final String SDK_VERSION="Java;12.17.1";
+    public static final String XML_VERSION="12.18";
+    public static final String SDK_VERSION="Java;12.18.0";
 
 }

--- a/src/main/xsd/cnpBatch_v12.18.xsd
+++ b/src/main/xsd/cnpBatch_v12.18.xsd
@@ -2,7 +2,7 @@
 <xs:schema targetNamespace="http://www.vantivcnp.com/schema" xmlns:xs="http://www.w3.org/2001/XMLSchema"
            xmlns:xp="http://www.vantivcnp.com/schema" elementFormDefault="qualified" attributeFormDefault="unqualified">
 
-    <xs:include schemaLocation="cnpTransaction_v12.17.xsd" />
+    <xs:include schemaLocation="cnpTransaction_v12.18.xsd" />
 
     <xs:element name="cnpRequest">
         <xs:complexType>
@@ -129,7 +129,7 @@
             <xs:complexContent>
                 <xs:extension base="xp:transactionTypeWithReportGroup">
                     <xs:all>
-                        <xs:element name="orderId" type="xp:string25Type" />
+                        <xs:element name="orderId" type="xp:string64Type" />
                         <xs:element ref="xp:cardOrToken" />
                     </xs:all>
                 </xs:extension>
@@ -177,7 +177,7 @@
                 <xs:extension base="xp:transactionTypeWithReportGroup">
                     <xs:all>
                         <xs:element name="cnpTxnId" type="xp:cnpIdType" />
-                        <xs:element name="orderId" type="xp:string25Type" />
+                        <xs:element name="orderId" type="xp:string64Type" />
                         <xs:element name="response" type="xp:responseType" />
                         <xs:element name="responseTime" type="xs:dateTime" />
                         <xs:element name="message" type="xp:messageType" />
@@ -226,7 +226,7 @@
             <xs:complexContent>
                 <xs:extension base="xp:transactionTypeWithReportGroup">
                     <xs:sequence>
-                        <xs:element name="orderId" type="xp:string25Type" />
+                        <xs:element name="orderId" type="xp:string64Type" />
                         <xs:element name="orderSource" type="xp:orderSourceType" />
                         <xs:element ref="xp:billToAddress" />
                         <xs:element name="echeck" type="xp:echeckType"/>
@@ -242,7 +242,7 @@
             <xs:complexContent>
                 <xs:extension base="xp:transactionTypeWithReportGroup">
                     <xs:sequence>
-                        <xs:element name="orderId" type="xp:string25Type" />
+                        <xs:element name="orderId" type="xp:string64Type" />
                         <xs:element name="orderSource" type="xp:orderSourceType" />
                         <xs:element ref="xp:billToAddress" />
                         <xs:element name="echeck" type="xp:echeckType"/>

--- a/src/main/xsd/cnpCommon_v12.18.xsd
+++ b/src/main/xsd/cnpCommon_v12.18.xsd
@@ -84,6 +84,12 @@
         </xs:restriction>
     </xs:simpleType>
 
+    <xs:simpleType name="string64Type">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="64" />
+        </xs:restriction>
+    </xs:simpleType>
+
     <xs:simpleType name="string80Type">
         <xs:restriction base="xs:string">
             <xs:maxLength value="80" />

--- a/src/main/xsd/cnpOnline_v12.18.xsd
+++ b/src/main/xsd/cnpOnline_v12.18.xsd
@@ -3,7 +3,7 @@
 <xs:schema targetNamespace="http://www.vantivcnp.com/schema" xmlns:xp="http://www.vantivcnp.com/schema"
            xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="unqualified">
 
-    <xs:include schemaLocation="cnpTransaction_v12.17.xsd" />
+    <xs:include schemaLocation="cnpTransaction_v12.18.xsd" />
 
     <xs:complexType name="baseRequest">
         <xs:sequence>
@@ -303,124 +303,124 @@
             </xs:complexContent>
         </xs:complexType>
     </xs:element>
+<!--
+    <xs:element name="vendorCredit" substitutionGroup="xp:transaction">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:choice>
+                        <xs:sequence>
+                            <xs:choice>
+                                <xs:element name="fundingCustomerId" type="xp:merchantIdentificationType" />
+                                <xs:element name="fundingSubmerchantId" type="xp:merchantIdentificationType" />
+                            </xs:choice>
+                            <xs:element name="vendorName" type="xp:string256Type"/>
+                            <xs:element name="fundsTransferId" type="xp:string36Type" />
+                            <xs:element name="amount" type="xp:transactionAmountType" />
+                            <xs:element name="accountInfo" type="xp:echeckType" />
+                        </xs:sequence>
+                    </xs:choice>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
 
-    <!--<xs:element name="vendorCredit" substitutionGroup="xp:transaction">-->
-        <!--<xs:complexType>-->
-            <!--<xs:complexContent>-->
-                <!--<xs:extension base="xp:transactionTypeWithReportGroup">-->
-                    <!--<xs:choice>-->
-                        <!--<xs:sequence>-->
-                            <!--<xs:choice>-->
-                                <!--<xs:element name="fundingCustomerId" type="xp:merchantIdentificationType" />-->
-                                <!--<xs:element name="fundingSubmerchantId" type="xp:merchantIdentificationType" />-->
-                            <!--</xs:choice>-->
-                            <!--<xs:element name="vendorName" type="xp:string256Type"/>-->
-                            <!--<xs:element name="fundsTransferId" type="xp:string36Type" />-->
-                            <!--<xs:element name="amount" type="xp:transactionAmountType" />-->
-                            <!--<xs:element name="accountInfo" type="xp:echeckType" />-->
-                        <!--</xs:sequence>-->
-                    <!--</xs:choice>-->
-                <!--</xs:extension>-->
-            <!--</xs:complexContent>-->
-        <!--</xs:complexType>-->
-    <!--</xs:element>-->
-
-    <!--<xs:element name="vendorDebit" substitutionGroup="xp:transaction">-->
-        <!--<xs:complexType>-->
-            <!--<xs:complexContent>-->
-                <!--<xs:extension base="xp:transactionTypeWithReportGroup">-->
-                    <!--<xs:choice>-->
-                        <!--<xs:sequence>-->
-                            <!--<xs:choice>-->
-                                <!--<xs:element name="fundingCustomerId" type="xp:merchantIdentificationType" />-->
-                                <!--<xs:element name="fundingSubmerchantId" type="xp:merchantIdentificationType" />-->
-                            <!--</xs:choice>-->
-                            <!--<xs:element name="vendorName" type="xp:string256Type"/>-->
-                            <!--<xs:element name="fundsTransferId" type="xp:string36Type" />-->
-                            <!--<xs:element name="amount" type="xp:transactionAmountType" />-->
-                            <!--<xs:element name="accountInfo" type="xp:echeckType" />-->
-                        <!--</xs:sequence>-->
-                    <!--</xs:choice>-->
-                <!--</xs:extension>-->
-            <!--</xs:complexContent>-->
-        <!--</xs:complexType>-->
-    <!--</xs:element>-->
+    <xs:element name="vendorDebit" substitutionGroup="xp:transaction">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:choice>
+                        <xs:sequence>
+                            <xs:choice>
+                                <xs:element name="fundingCustomerId" type="xp:merchantIdentificationType" />
+                                <xs:element name="fundingSubmerchantId" type="xp:merchantIdentificationType" />
+                            </xs:choice>
+                            <xs:element name="vendorName" type="xp:string256Type"/>
+                            <xs:element name="fundsTransferId" type="xp:string36Type" />
+                            <xs:element name="amount" type="xp:transactionAmountType" />
+                            <xs:element name="accountInfo" type="xp:echeckType" />
+                        </xs:sequence>
+                    </xs:choice>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
 
 
-    <!--<xs:element name="submerchantCredit" substitutionGroup="xp:transaction">-->
-        <!--<xs:complexType>-->
-            <!--<xs:complexContent>-->
-                <!--<xs:extension base="xp:transactionTypeWithReportGroup">-->
-                    <!--<xs:choice>-->
-                        <!--<xs:sequence>-->
-                            <!--<xs:element name="fundingSubmerchantId" type="xp:merchantIdentificationType" />-->
-                            <!--<xs:element name="submerchantName" type="xp:string256Type"/>-->
-                            <!--<xs:element name="fundsTransferId" type="xp:string36Type" />-->
-                            <!--<xs:element name="amount" type="xp:transactionAmountType" />-->
-                            <!--<xs:element name="accountInfo" type="xp:echeckType" />-->
-                            <!--<xs:element name="customIdentifier" type="xp:string15Type" minOccurs="0" />-->
-                        <!--</xs:sequence>-->
-                    <!--</xs:choice>-->
-                <!--</xs:extension>-->
-            <!--</xs:complexContent>-->
-        <!--</xs:complexType>-->
-    <!--</xs:element>-->
+    <xs:element name="submerchantCredit" substitutionGroup="xp:transaction">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:choice>
+                        <xs:sequence>
+                            <xs:element name="fundingSubmerchantId" type="xp:merchantIdentificationType" />
+                            <xs:element name="submerchantName" type="xp:string256Type"/>
+                            <xs:element name="fundsTransferId" type="xp:string36Type" />
+                            <xs:element name="amount" type="xp:transactionAmountType" />
+                            <xs:element name="accountInfo" type="xp:echeckType" />
+                            <xs:element name="customIdentifier" type="xp:string15Type" minOccurs="0" />
+                        </xs:sequence>
+                    </xs:choice>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
 
-    <!--<xs:element name="submerchantDebit" substitutionGroup="xp:transaction">-->
-        <!--<xs:complexType>-->
-            <!--<xs:complexContent>-->
-                <!--<xs:extension base="xp:transactionTypeWithReportGroup">-->
-                    <!--<xs:choice>-->
-                        <!--<xs:sequence>-->
-                            <!--<xs:element name="fundingSubmerchantId" type="xp:merchantIdentificationType" />-->
-                            <!--<xs:element name="submerchantName" type="xp:string256Type"/>-->
-                            <!--<xs:element name="fundsTransferId" type="xp:string36Type" />-->
-                            <!--<xs:element name="amount" type="xp:transactionAmountType" />-->
-                            <!--<xs:element name="accountInfo" type="xp:echeckType" />-->
-                            <!--<xs:element name="customIdentifier" type="xp:string15Type" minOccurs="0" />-->
-                        <!--</xs:sequence>-->
-                    <!--</xs:choice>-->
-                <!--</xs:extension>-->
-            <!--</xs:complexContent>-->
-        <!--</xs:complexType>-->
-    <!--</xs:element>-->
+    <xs:element name="submerchantDebit" substitutionGroup="xp:transaction">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:choice>
+                        <xs:sequence>
+                            <xs:element name="fundingSubmerchantId" type="xp:merchantIdentificationType" />
+                            <xs:element name="submerchantName" type="xp:string256Type"/>
+                            <xs:element name="fundsTransferId" type="xp:string36Type" />
+                            <xs:element name="amount" type="xp:transactionAmountType" />
+                            <xs:element name="accountInfo" type="xp:echeckType" />
+                            <xs:element name="customIdentifier" type="xp:string15Type" minOccurs="0" />
+                        </xs:sequence>
+                    </xs:choice>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
 
-    <!--<xs:element name="customerCredit" substitutionGroup="xp:transaction">-->
-        <!--<xs:complexType>-->
-            <!--<xs:complexContent>-->
-                <!--<xs:extension base="xp:transactionTypeWithReportGroup">-->
-                    <!--<xs:choice>-->
-                        <!--<xs:sequence>-->
-                            <!--<xs:element name="fundingCustomerId" type="xp:merchantIdentificationType" />-->
-                            <!--<xs:element name="customerName" type="xp:string256Type"/>-->
-                            <!--<xs:element name="fundsTransferId" type="xp:string36Type" />-->
-                            <!--<xs:element name="amount" type="xp:transactionAmountType" />-->
-                            <!--<xs:element name="accountInfo" type="xp:echeckType" />-->
-                            <!--<xs:element name="customIdentifier" type="xp:string15Type" minOccurs="0" />-->
-                        <!--</xs:sequence>-->
-                    <!--</xs:choice>-->
-                <!--</xs:extension>-->
-            <!--</xs:complexContent>-->
-        <!--</xs:complexType>-->
-    <!--</xs:element>-->
+    <xs:element name="customerCredit" substitutionGroup="xp:transaction">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:choice>
+                        <xs:sequence>
+                            <xs:element name="fundingCustomerId" type="xp:merchantIdentificationType" />
+                            <xs:element name="customerName" type="xp:string256Type"/>
+                            <xs:element name="fundsTransferId" type="xp:string36Type" />
+                            <xs:element name="amount" type="xp:transactionAmountType" />
+                            <xs:element name="accountInfo" type="xp:echeckType" />
+                            <xs:element name="customIdentifier" type="xp:string15Type" minOccurs="0" />
+                        </xs:sequence>
+                    </xs:choice>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
 
-    <!--<xs:element name="customerDebit" substitutionGroup="xp:transaction">-->
-        <!--<xs:complexType>-->
-            <!--<xs:complexContent>-->
-                <!--<xs:extension base="xp:transactionTypeWithReportGroup">-->
-                    <!--<xs:choice>-->
-                        <!--<xs:sequence>-->
-                            <!--<xs:element name="fundingCustomerId" type="xp:merchantIdentificationType" />-->
-                            <!--<xs:element name="customerName" type="xp:string256Type"/>-->
-                            <!--<xs:element name="fundsTransferId" type="xp:string36Type" />-->
-                            <!--<xs:element name="amount" type="xp:transactionAmountType" />-->
-                            <!--<xs:element name="accountInfo" type="xp:echeckType" />-->
-                            <!--<xs:element name="customIdentifier" type="xp:string15Type" minOccurs="0" />-->
-                        <!--</xs:sequence>-->
-                    <!--</xs:choice>-->
-                <!--</xs:extension>-->
-            <!--</xs:complexContent>-->
-        <!--</xs:complexType>-->
-    <!--</xs:element>-->
-
+    <xs:element name="customerDebit" substitutionGroup="xp:transaction">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:choice>
+                        <xs:sequence>
+                            <xs:element name="fundingCustomerId" type="xp:merchantIdentificationType" />
+                            <xs:element name="customerName" type="xp:string256Type"/>
+                            <xs:element name="fundsTransferId" type="xp:string36Type" />
+                            <xs:element name="amount" type="xp:transactionAmountType" />
+                            <xs:element name="accountInfo" type="xp:echeckType" />
+                            <xs:element name="customIdentifier" type="xp:string15Type" minOccurs="0" />
+                        </xs:sequence>
+                    </xs:choice>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+-->
 </xs:schema>

--- a/src/main/xsd/cnpRecurring_v12.18.xsd
+++ b/src/main/xsd/cnpRecurring_v12.18.xsd
@@ -1,7 +1,7 @@
 <xs:schema targetNamespace="http://www.vantivcnp.com/schema" xmlns:xp="http://www.vantivcnp.com/schema"
            xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="unqualified">
 
-    <xs:include schemaLocation="cnpCommon_v12.17.xsd" />
+    <xs:include schemaLocation="cnpCommon_v12.18.xsd" />
 
     <xs:element name="recurringTransaction" type="xp:recurringTransactionType" abstract="true" />
     <xs:element name="recurringTransactionResponse" type="xp:recurringTransactionResponseType" abstract="true" />

--- a/src/main/xsd/cnpTransaction_v12.18.xsd
+++ b/src/main/xsd/cnpTransaction_v12.18.xsd
@@ -1,8 +1,8 @@
 <xs:schema targetNamespace="http://www.vantivcnp.com/schema" xmlns:xp="http://www.vantivcnp.com/schema"
            xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="unqualified">
 
-    <xs:include schemaLocation="cnpCommon_v12.17.xsd" />
-    <xs:include schemaLocation="cnpRecurring_v12.17.xsd" />
+    <xs:include schemaLocation="cnpCommon_v12.18.xsd" />
+    <xs:include schemaLocation="cnpRecurring_v12.18.xsd" />
 
     <xs:element name="transaction" type="xp:transactionType" abstract="true" />
 
@@ -129,7 +129,7 @@
                             <xs:element name="cnpTxnId" type="xp:cnpIdType" />
                         </xs:sequence>
                         <xs:sequence>
-                            <xs:element name="orderId" type="xp:string25Type" />
+                            <xs:element name="orderId" type="xp:string64Type" />
                             <xs:element name="amount" type="xp:transactionAmountType" />
                             <xs:element name="secondaryAmount" type="xp:transactionAmountType" minOccurs="0" />
                             <xs:element name="surchargeAmount" type="xp:transactionAmountType" minOccurs="0" />
@@ -253,7 +253,7 @@
             <xs:complexContent>
                 <xs:extension base="xp:transactionTypeWithReportGroup">
                     <xs:sequence>
-                        <xs:element name="orderId" type="xp:string25Type" />
+                        <xs:element name="orderId" type="xp:string64Type" />
                         <xs:element name="amount" type="xp:transactionAmountType" />
                         <xs:element name="secondaryAmount" type="xp:transactionAmountType" minOccurs="0" />
                         <xs:element name="surchargeAmount" type="xp:transactionAmountType" minOccurs="0" />
@@ -287,7 +287,7 @@
             <xs:complexContent>
                 <xs:extension base="xp:transactionTypeWithReportGroup">
                     <xs:sequence>
-                        <xs:element name="orderId" type="xp:string25Type" />
+                        <xs:element name="orderId" type="xp:string64Type" />
                         <xs:element ref="xp:authInformation" />
                         <xs:element name="amount" type="xp:transactionAmountType" />
                         <xs:element name="secondaryAmount" type="xp:transactionAmountType" minOccurs="0" />
@@ -327,7 +327,7 @@
                     <xs:sequence>
                         <!-- This element was missing from the 6.2 online version but in the 6.2 online castor mapping.  Batch version used here for consistence -->
                         <xs:element name="cnpTxnId" type="xp:cnpIdType" minOccurs="0" />
-                        <xs:element name="orderId" type="xp:string25Type" />
+                        <xs:element name="orderId" type="xp:string64Type" />
                         <xs:element name="amount" type="xp:transactionAmountType" />
                         <xs:element name="secondaryAmount" type="xp:transactionAmountType" minOccurs="0" />
                         <xs:element name="surchargeAmount" type="xp:transactionAmountType" minOccurs="0" />
@@ -405,7 +405,7 @@
                                 <xs:element name="pin" type="xp:pinType" minOccurs="0" />
                             </xs:sequence>
                             <xs:sequence>
-                                <xs:element name="orderId" type="xp:string25Type" />
+                                <xs:element name="orderId" type="xp:string64Type" />
                                 <xs:element name="amount" type="xp:transactionAmountType" />
                                 <xs:element name="secondaryAmount" type="xp:transactionAmountType" minOccurs="0" />
                                 <xs:element name="surchargeAmount" type="xp:transactionAmountType" minOccurs="0" />
@@ -472,7 +472,7 @@
                                 <xs:element name="card" type="xp:giftCardCardType" />
                             </xs:sequence>
                             <xs:sequence>
-                                <xs:element name="orderId" type="xp:string25Type" />
+                                <xs:element name="orderId" type="xp:string64Type" />
                                 <xs:element name="creditAmount" type="xp:transactionAmountType" />
                                 <xs:element name="orderSource" type="xp:orderSourceType" />
                                 <xs:element name="card" type="xp:giftCardCardType" />
@@ -489,7 +489,7 @@
             <xs:complexContent>
                 <xs:extension base="xp:transactionTypeWithReportGroup">
                     <xs:sequence>
-                        <xs:element name="orderId" type="xp:string25Type" />
+                        <xs:element name="orderId" type="xp:string64Type" />
                         <xs:element name="amount" type="xp:transactionAmountType" minOccurs="1" />
                         <xs:element name="orderSource" type="xp:orderSourceType" />
                         <xs:choice>
@@ -507,7 +507,7 @@
             <xs:complexContent>
                 <xs:extension base="xp:transactionTypeWithReportGroup">
                     <xs:sequence>
-                        <xs:element name="orderId" type="xp:string25Type" />
+                        <xs:element name="orderId" type="xp:string64Type" />
                         <xs:element name="orderSource" type="xp:orderSourceType" />
                         <xs:element name="card" type="xp:giftCardCardType" minOccurs="1" />
                     </xs:sequence>
@@ -521,7 +521,7 @@
             <xs:complexContent>
                 <xs:extension base="xp:transactionTypeWithReportGroup">
                     <xs:sequence>
-                        <xs:element name="orderId" type="xp:string25Type" />
+                        <xs:element name="orderId" type="xp:string64Type" />
                         <xs:element name="amount" type="xp:transactionAmountType" minOccurs="1" />
                         <xs:element name="orderSource" type="xp:orderSourceType" />
                         <xs:element name="card" type="xp:giftCardCardType" minOccurs="1" />
@@ -536,7 +536,7 @@
             <xs:complexContent>
                 <xs:extension base="xp:transactionTypeWithReportGroup">
                     <xs:sequence>
-                        <xs:element name="orderId" type="xp:string25Type" />
+                        <xs:element name="orderId" type="xp:string64Type" />
                         <xs:element name="amount" type="xp:transactionAmountType" minOccurs="1" />
                         <xs:element name="orderSource" type="xp:orderSourceType" />
                         <xs:element name="card" type="xp:giftCardCardType" minOccurs="1" />
@@ -564,7 +564,7 @@
             <xs:complexContent>
                 <xs:extension base="xp:transactionTypeWithReportGroup">
                     <xs:sequence>
-                        <xs:element name="orderId" type="xp:string25Type" />
+                        <xs:element name="orderId" type="xp:string64Type" />
                         <xs:element name="orderSource" type="xp:orderSourceType" />
                         <xs:element name="card" type="xp:giftCardCardType" minOccurs="1" />
                     </xs:sequence>
@@ -757,7 +757,7 @@
             <xs:extension base="xp:transactionTypeWithReportGroup">
                 <xs:sequence>
                     <xs:element name="encryptionKeyId" type="xp:string25Type" minOccurs="0" />
-                    <xs:element name="orderId" type="xp:string25Type" minOccurs="0" />
+                    <xs:element name="orderId" type="xp:string64Type" minOccurs="0" />
                     <xs:choice>
                         <xs:element name="mpos" type="xp:mposType" />
                         <xs:element name="accountNumber" type="xp:ccAccountNumberType" />
@@ -807,7 +807,7 @@
                 <xs:extension base="xp:transactionTypeWithReportGroup">
                     <xs:all>
                         <xs:element name="cnpTxnId" type="xp:cnpIdType" />
-                        <xs:element name="orderId" type="xp:string25Type" />
+                        <xs:element name="orderId" type="xp:string64Type" />
                         <xs:element name="response" type="xp:responseType" />
                         <xs:element name="responseTime" type="xs:dateTime" />
                         <xs:element name="cardProductId" type="xs:string" minOccurs="0" />
@@ -1255,7 +1255,7 @@
                     <xs:all>
                         <xs:element name="cnpTxnId" type="xp:cnpIdType" />
                         <xs:element name="response" type="xp:responseType" />
-                        <xs:element name="orderId" type="xp:string25Type" />
+                        <xs:element name="orderId" type="xp:string64Type" />
                         <xs:element name="responseTime" type="xs:dateTime" />
                         <xs:element name="cardProductId" type="xs:string" minOccurs="0" />
                         <xs:element name="postDate" type="xs:date" minOccurs="0" />
@@ -1491,7 +1491,7 @@
                             <xs:element name="customIdentifier" type="xp:string15Type" minOccurs="0" />
                         </xs:sequence>
                         <xs:sequence>
-                            <xs:element name="orderId" type="xp:string25Type" />
+                            <xs:element name="orderId" type="xp:string64Type" />
                             <xs:element name="verify" type="xs:boolean" minOccurs="0" />
                             <xs:element name="amount" type="xp:transactionAmountType" />
                             <xs:element name="secondaryAmount" type="xp:transactionAmountType" minOccurs="0" />
@@ -1523,7 +1523,7 @@
                                 <xs:element name="customIdentifier" type="xp:string15Type" minOccurs="0" />
                             </xs:sequence>
                             <xs:sequence>
-                                <xs:element name="orderId" type="xp:string25Type" />
+                                <xs:element name="orderId" type="xp:string64Type" />
                                 <xs:element name="amount" type="xp:transactionAmountType" />
                                 <xs:element name="secondaryAmount" type="xp:transactionAmountType" minOccurs="0" />
                                 <xs:element name="orderSource" type="xp:orderSourceType" />
@@ -1545,7 +1545,7 @@
             <xs:complexContent>
                 <xs:extension base="xp:transactionTypeWithReportGroup">
                     <xs:sequence>
-                        <xs:element name="orderId" type="xp:string25Type" />
+                        <xs:element name="orderId" type="xp:string64Type" />
                         <xs:element name="amount" type="xp:transactionAmountType" /> <!-- required but not tied to sale -->
                         <xs:element name="orderSource" type="xp:orderSourceType" />
                         <xs:element ref="xp:billToAddress" minOccurs="1" />  <!-- must supply street, city and state as 2 digit postal state -->
@@ -2013,7 +2013,7 @@
         <xs:complexContent>
             <xs:extension base="xp:transactionTypeWithReportGroup">
                 <xs:sequence>
-                    <xs:element name="orderId" type="xp:string25Type" minOccurs="0" />
+                    <xs:element name="orderId" type="xp:string64Type" minOccurs="0" />
                     <xs:element name="cnpToken" type="xp:ccAccountNumberType" />
                     <xs:element name="cardValidationNum" type="xp:cvNumType"/>
                 </xs:sequence>
@@ -2861,7 +2861,7 @@
         <xs:complexContent>
             <xs:extension base="xp:transactionTypeWithReportGroup">
                 <xs:sequence>
-                    <xs:element name="orderId" type="xp:string25Type" minOccurs="0" />
+                    <xs:element name="orderId" type="xp:string64Type" minOccurs="0" />
                     <xs:element name="token" type="xp:string512Type" minOccurs="1" />
                 </xs:sequence>
             </xs:extension>
@@ -2873,7 +2873,7 @@
             <xs:complexContent>
                 <xs:extension base="xp:transactionTypeWithReportGroup">
                     <xs:all>
-                        <xs:element name="orderId" type="xp:string25Type" minOccurs="0" />
+                        <xs:element name="orderId" type="xp:string64Type" minOccurs="0" />
                         <xs:element name="paypageRegistrationId" type="xp:string512Type"  minOccurs="0" />
                         <xs:element name="response" type="xp:responseType" />
                         <xs:element name="message" type="xs:string"/>


### PR DESCRIPTION
```
==Version 12.18.0 (November 30, 2020)
* Feature: Added support for orderId to be up to 64 characters in length (for transaction types)
```