### PR TITLE
Feature 129391 v12.24

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,20 @@
 = Vantiv eCommerce CNP CHANGELOG
 
+==Version 12.24.0 (April 4, 2022)
+* Change: [cnpAPI v12.23] Added a new value in businessIndicatorEnum to support businessIndicator element :buyOnlinePickUpInStore.
+* Change: [cnpAPI v12.23] Added  new element :orderChannel for Auth/sale transaction request.
+* Change: [cnpAPI v12.23] Added new elements(accountUsername, userAccountNumber, userAccountEmail, membershipId, membershipPhone, membershipEmail, membershipName, accountCreatedDate and userAccountPhone) in customerInfo type.
+* Change: [cnpAPI v12.23] Added new elements:sellerId , url to support contact type which is referenced by retailerAddress
+* Change: [cnpAPI v12.23] Added new elements retailerAddress,additionalCOFData to support Auth/Sale/CaptureGivenAuth.
+* Change: [cnpAPI v12.23] Added a new elements:discountCode,discountPercent,fulfilmentMethodType in enhancedData.
+* Change: [cnpAPI v12.23] Added a new elements:itemCategory,itemSubCategory,productId,productName in LineItemData
+* Change: [cnpAPI v12.24] Added a new values in businessIndicatorEnum to support businessIndicator element :highRiskSecuritiesPurchase,fundTransfer,walletTransfer
+* Change: [cnpAPI v12.24] Added OrderChannelEnum to support  element :orderChannel for Auth/sale transaction request.
+* Change: [cnpAPI v12.24] Added fulfilmentMethodTypeEnum to support  element fulfilmentMethodType in enhancedData type
+* Change: [cnpAPI v12.24] Added new value in frequencyOfMITEnum: Annually(It was Anually- Incorrect spelling in earlier version.)
+* Change: [cnpAPI v12.24] Added new element crypto to support Auth/Sale/CaptureGivenAuth.
+* Change: [cnpAPI v12.24] Added new element fraudCheckStatus to support Auth/Sale.
+
 ==Version 12.22.0 (March 28, 2022)
 * Change: New element introduced for different request.
 * Change: new element :address is added in vendorCredit/vendorDebit/FastAccessFunding.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 DIST_DIR_15=build/dist/java15
-JAR_VERSION=12.22.0
+JAR_VERSION=12.24.0
 KIT_DIR=build/kit/java15
 KIT_DEPENDENCIES_DIR=build/kit/java15/dependencies
 OPENSFTP_DIR=lib/opensftp-0.3.0
-SCHEMA_VERSION=12.22
+SCHEMA_VERSION=12.24

--- a/src/functionalTest/java/io/github/vantiv/sdk/TestAuth.java
+++ b/src/functionalTest/java/io/github/vantiv/sdk/TestAuth.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.math.BigInteger;
+import java.util.Calendar;
 
 //import com.cnp.sdk.generate.*;
 import io.github.vantiv.sdk.generate.*;
@@ -73,8 +74,8 @@ public class TestAuth {
 		card.setNumber("4100000000000000");
 		card.setExpDate("1210");
 		authorization.setCard(card);
-		authorization.setBusinessIndicator(BusinessIndicatorEnum.CONSUMER_BILL_PAYMENT);
-
+		//authorization.setBusinessIndicator(BusinessIndicatorEnum.CONSUMER_BILL_PAYMENT);
+        authorization.setBusinessIndicator(BusinessIndicatorEnum.WALLET_TRANSFER);
 		AuthorizationResponse response = cnp.authorize(authorization);
 		assertEquals(response.getMessage(), "000",response.getResponse());
 		assertEquals("Approved", response.getMessage());
@@ -465,6 +466,133 @@ public class TestAuth {
 
 		AuthorizationResponse response = cnp.authorize(authorization);
 		assertEquals(response.getMessage(), "000",response.getResponse());
+		assertEquals("sandbox", response.getLocation());
+	}
+
+	@Test
+	public void testAuthWithCustomerInfo() throws Exception {
+		Authorization authorization = new Authorization();
+		authorization.setId("12345");
+		authorization.setReportGroup("Default");
+		authorization.setOrderId("67890");
+		authorization.setAmount(10000L);
+		authorization.setOrderSource(OrderSourceType.ECOMMERCE);
+		CustomerInfo cust = new CustomerInfo();
+		cust.setAccountUsername("Woolfoo");
+		cust.setUserAccountNumber("123456ATY");
+		cust.setUserAccountEmail("woolfoo@gmail.com");
+		cust.setMembershipId("Member01");
+		cust.setMembershipPhone("9765431234");
+		cust.setMembershipEmail("mem@abc.com");
+		cust.setMembershipName("memName");
+		Calendar createDate = Calendar.getInstance();
+		createDate.set(1990, Calendar.MARCH, 16);
+		cust.setAccountCreatedDate(createDate);
+		cust.setUserAccountPhone("123456789");
+		authorization.setCustomerInfo(cust);
+		CardType card = new CardType();
+		card.setNumber("4100000000000000");
+		card.setExpDate("1215");
+		card.setType(MethodOfPaymentTypeEnum.VI);
+		authorization.setCard(card);
+		AuthorizationResponse response = cnp.authorize(authorization);
+		assertEquals(response.getMessage(), "Approved", response.getMessage());
+		assertEquals("sandbox", response.getLocation());
+	}
+
+	@Test
+	public void testAuthWithEnhancedDataLineItemDataOrdChanelfraudCheckStatusCrypto() throws Exception {
+		Authorization authorization = new Authorization();
+		authorization.setId("12345");
+		authorization.setReportGroup("Default");
+		authorization.setOrderId("67890");
+		authorization.setAmount(10000L);
+		authorization.setOrderSource(OrderSourceType.ECOMMERCE);
+		CardType card = new CardType();
+		card.setNumber("4100000000000000");
+		card.setExpDate("1215");
+		card.setType(MethodOfPaymentTypeEnum.VI);
+		authorization.setCard(card);
+		EnhancedData enhanced = new EnhancedData();
+		enhanced.setCustomerReference("Cust Ref");
+		enhanced.setSalesTax(1000L);
+		LineItemData lid = new LineItemData();
+		lid.setItemSequenceNumber(1);
+		lid.setItemDescription("Electronics");
+		lid.setProductCode("El01");
+		lid.setItemCategory("Ele Appiances");
+		lid.setItemSubCategory("home appliaces");
+		lid.setProductId("1001");
+		lid.setProductName("dryer");
+		enhanced.getLineItemDatas().add(lid);
+		enhanced.setDiscountCode("oneTimeDis");
+		enhanced.setDiscountPercent(BigInteger.valueOf(12));
+		enhanced.setFulfilmentMethodType(FulfilmentMethodTypeEnum.COUNTER_PICKUP);
+		authorization.setEnhancedData(enhanced);
+		authorization.setOrderChannel(OrderChannelEnum.IN_STORE_KIOSK);
+		authorization.setFraudCheckStatus("CLOSE");
+		authorization.setCrypto(false);
+		AuthorizationResponse response = cnp.authorize(authorization);
+		assertEquals(response.getMessage(), "Approved", response.getMessage());
+		assertEquals("sandbox", response.getLocation());
+	}
+
+	@Test
+	public void testAuthWithAdditionalCOFData() throws Exception {
+		Authorization authorization = new Authorization();
+		authorization.setId("12345");
+		authorization.setReportGroup("Default");
+		authorization.setOrderId("67890");
+		authorization.setAmount(10000L);
+		authorization.setOrderSource(OrderSourceType.ECOMMERCE);
+		CardType card = new CardType();
+		card.setNumber("4100000000000000");
+		card.setExpDate("1215");
+		card.setType(MethodOfPaymentTypeEnum.VI);
+		authorization.setCard(card);
+		AdditionalCOFData data = new AdditionalCOFData();
+		data.setUniqueId("56655678D");
+		data.setTotalPaymentCount("35");
+		data.setFrequencyOfMIT(FrequencyOfMITEnum.ANNUALLY);
+		data.setPaymentType(PaymentTypeEnum.FIXED_AMOUNT);
+		data.setValidationReference("asd123");
+		data.setSequenceIndicator(BigInteger.valueOf(12));
+		authorization.setAdditionalCOFData(data);
+		AuthorizationResponse response = cnp.authorize(authorization);
+		assertEquals(response.getMessage(), "Approved", response.getMessage());
+		assertEquals("sandbox", response.getLocation());
+	}
+	@Test
+	public void simpleAuthWithRetailerAddress() throws Exception {
+		Authorization authorization = new Authorization();
+		authorization.setReportGroup("Planets");
+		authorization.setOrderId("12344");
+		authorization.setAmount(106L);
+		authorization.setOrderSource(OrderSourceType.ECOMMERCE);
+		authorization.setId("id");
+		FraudCheckType fraudCheckType = new FraudCheckType();
+		authorization.setCardholderAuthentication(fraudCheckType);
+		CardType card = new CardType();
+		card.setType(MethodOfPaymentTypeEnum.VI);
+		card.setNumber("4100000000000000");
+		card.setExpDate("1210");
+		authorization.setCard(card);
+		Contact contact = new Contact();
+		contact.setSellerId("12386576");
+		contact.setCompanyName("fis Global");
+		contact.setAddressLine1("Pune East");
+		contact.setAddressLine2("Pune west");
+		contact.setAddressLine3("Pune north");
+		contact.setCity("lowell");
+		contact.setState("MA");
+		contact.setZip("825320");
+		contact.setCountry(CountryTypeEnum.IN);
+		contact.setEmail("cnp.com");
+		contact.setPhone("8880129170");
+		contact.setUrl("www.lowel.com");
+		authorization.setRetailerAddress(contact);
+		AuthorizationResponse response = cnp.authorize(authorization);
+		assertEquals( "Approved",response.getMessage());
 		assertEquals("sandbox", response.getLocation());
 	}
 }

--- a/src/functionalTest/java/io/github/vantiv/sdk/TestCaptureGivenAuth.java
+++ b/src/functionalTest/java/io/github/vantiv/sdk/TestCaptureGivenAuth.java
@@ -2,23 +2,12 @@ package io.github.vantiv.sdk;
 
 import static org.junit.Assert.assertEquals;
 
+import java.math.BigInteger;
 import java.util.Calendar;
 
+import io.github.vantiv.sdk.generate.*;
 import org.junit.BeforeClass;
 import org.junit.Test;
-
-import io.github.vantiv.sdk.generate.AuthInformation;
-import io.github.vantiv.sdk.generate.BusinessIndicatorEnum;
-import io.github.vantiv.sdk.generate.CaptureGivenAuth;
-import io.github.vantiv.sdk.generate.CaptureGivenAuthResponse;
-import io.github.vantiv.sdk.generate.CardTokenType;
-import io.github.vantiv.sdk.generate.CardType;
-import io.github.vantiv.sdk.generate.Contact;
-import io.github.vantiv.sdk.generate.FraudResult;
-import io.github.vantiv.sdk.generate.MethodOfPaymentTypeEnum;
-import io.github.vantiv.sdk.generate.OrderSourceType;
-import io.github.vantiv.sdk.generate.ProcessingInstructions;
-import io.github.vantiv.sdk.generate.ProcessingTypeEnum;
 
 public class TestCaptureGivenAuth {
 
@@ -273,6 +262,119 @@ public class TestCaptureGivenAuth {
 		card.setExpDate("1210");
 		capturegivenauth.setCard(card);
 		capturegivenauth.setId("id");
+		CaptureGivenAuthResponse response = cnp.captureGivenAuth(capturegivenauth);
+		assertEquals("Approved", response.getMessage());
+		assertEquals("sandbox", response.getLocation());
+	}
+
+	@Test
+	public void testCaptureGivenAuthWithEnhancedDataLineItemDataBussinessIndiCrypto() throws Exception {
+		CaptureGivenAuth capturegivenauth = new CaptureGivenAuth();
+		capturegivenauth.setAmount(106L);
+		capturegivenauth.setOrderId("12344");
+		AuthInformation authInfo = new AuthInformation();
+		Calendar authDate = Calendar.getInstance();
+		authDate.set(2002, Calendar.OCTOBER, 9);
+		authInfo.setAuthDate(authDate);
+		authInfo.setAuthCode("543216");
+		authInfo.setAuthAmount(12345L);
+		capturegivenauth.setAuthInformation(authInfo);
+		capturegivenauth.setOrderSource(OrderSourceType.ECOMMERCE);
+		CardTokenType cardtoken = new CardTokenType();
+		cardtoken.setTokenURL("http://token.com/sales");
+		cardtoken.setExpDate("1210");
+		cardtoken.setCardValidationNum("555");
+		cardtoken.setType(MethodOfPaymentTypeEnum.VI);
+		capturegivenauth.setToken(cardtoken);
+		capturegivenauth.setId("id");
+		EnhancedData enhanced = new EnhancedData();
+		enhanced.setCustomerReference("Cust Ref");
+		enhanced.setSalesTax(1000L);
+		LineItemData lid = new LineItemData();
+		lid.setItemSequenceNumber(1);
+		lid.setItemDescription("Electronics");
+		lid.setProductCode("El01");
+		lid.setItemCategory("Ele Appiances");
+		lid.setItemSubCategory("home appliaces");
+		lid.setProductId("1001");
+		lid.setProductName("dryer");
+		enhanced.getLineItemDatas().add(lid);
+		enhanced.setDiscountCode("oneTimeDis");
+		enhanced.setDiscountPercent(BigInteger.valueOf(12));
+		enhanced.setFulfilmentMethodType(FulfilmentMethodTypeEnum.COUNTER_PICKUP);
+		capturegivenauth.setEnhancedData(enhanced);
+		capturegivenauth.setBusinessIndicator(BusinessIndicatorEnum.FUND_TRANSFER);
+		capturegivenauth.setCrypto(false);
+		CaptureGivenAuthResponse response = cnp.captureGivenAuth(capturegivenauth);
+		assertEquals(response.getMessage(), "Approved", response.getMessage());
+		assertEquals("sandbox", response.getLocation());
+	}
+
+	@Test
+	public void testCaptureGivenAuthWithAdditionalCOFData() throws Exception {
+		CaptureGivenAuth capturegivenauth = new CaptureGivenAuth();
+		capturegivenauth.setAmount(106L);
+		capturegivenauth.setOrderId("12344");
+		AuthInformation authInfo = new AuthInformation();
+		Calendar authDate = Calendar.getInstance();
+		authDate.set(2002, Calendar.OCTOBER, 9);
+		authInfo.setAuthDate(authDate);
+		authInfo.setAuthCode("543216");
+		authInfo.setAuthAmount(12345L);
+		capturegivenauth.setAuthInformation(authInfo);
+		capturegivenauth.setOrderSource(OrderSourceType.ECOMMERCE);
+		CardTokenType cardtoken = new CardTokenType();
+		cardtoken.setTokenURL("http://token.com/sales");
+		cardtoken.setExpDate("1210");
+		cardtoken.setCardValidationNum("555");
+		cardtoken.setType(MethodOfPaymentTypeEnum.VI);
+		capturegivenauth.setToken(cardtoken);
+		capturegivenauth.setId("id");
+		AdditionalCOFData data = new AdditionalCOFData();
+		data.setUniqueId("56655678D");
+		data.setTotalPaymentCount("35");
+		data.setFrequencyOfMIT(FrequencyOfMITEnum.ANNUALLY);
+		data.setPaymentType(PaymentTypeEnum.FIXED_AMOUNT);
+		data.setValidationReference("asd123");
+		data.setSequenceIndicator(BigInteger.valueOf(12));
+		capturegivenauth.setAdditionalCOFData(data);
+		CaptureGivenAuthResponse response = cnp.captureGivenAuth(capturegivenauth);
+		assertEquals(response.getMessage(), "Approved", response.getMessage());
+		assertEquals("sandbox", response.getLocation());
+	}
+	@Test
+	public void simpleCaptureGivenAuthWithRetailerAddress() throws Exception{
+		CaptureGivenAuth capturegivenauth = new CaptureGivenAuth();
+		capturegivenauth.setAmount(106L);
+		capturegivenauth.setOrderId("12344");
+		AuthInformation authInfo = new AuthInformation();
+		Calendar authDate = Calendar.getInstance();
+		authDate.set(2002, Calendar.OCTOBER, 9);
+		authInfo.setAuthDate(authDate);
+		authInfo.setAuthCode("543216");
+		authInfo.setAuthAmount(12345L);
+		capturegivenauth.setAuthInformation(authInfo);
+		capturegivenauth.setOrderSource(OrderSourceType.ECOMMERCE);
+		CardType card = new CardType();
+		card.setType(MethodOfPaymentTypeEnum.VI);
+		card.setNumber("4100000000000000");
+		card.setExpDate("1210");
+		capturegivenauth.setCard(card);
+		capturegivenauth.setId("id");
+		Contact contact = new Contact();
+		contact.setSellerId("12386576");
+		contact.setCompanyName("fis Global");
+		contact.setAddressLine1("Pune East");
+		contact.setAddressLine2("Pune west");
+		contact.setAddressLine3("Pune north");
+		contact.setCity("lowell");
+		contact.setState("MA");
+		contact.setZip("825320");
+		contact.setCountry(CountryTypeEnum.IN);
+		contact.setEmail("cnp.com");
+		contact.setPhone("8880129170");
+		contact.setUrl("www.lowel.com");
+		capturegivenauth.setRetailerAddress(contact);
 		CaptureGivenAuthResponse response = cnp.captureGivenAuth(capturegivenauth);
 		assertEquals("Approved", response.getMessage());
 		assertEquals("sandbox", response.getLocation());

--- a/src/functionalTest/java/io/github/vantiv/sdk/TestSale.java
+++ b/src/functionalTest/java/io/github/vantiv/sdk/TestSale.java
@@ -7,6 +7,9 @@ import io.github.vantiv.sdk.generate.*;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.math.BigInteger;
+import java.util.Calendar;
+
 public class TestSale {
 
 	private static CnpOnline cnp;
@@ -342,6 +345,132 @@ public class TestSale {
 		card.setExpDate("1210");
 		sale.setCard(card);
 		sale.setId("id");
+		SaleResponse response = cnp.sale(sale);
+		assertEquals("Approved", response.getMessage());
+		assertEquals("sandbox", response.getLocation());
+	}
+
+	@Test
+	public void testSaleWithCustomerInfo() throws Exception {
+		Sale sale = new Sale();
+		sale.setId("12345");
+		sale.setReportGroup("Default");
+		sale.setOrderId("67890");
+		sale.setAmount(10000L);
+		sale.setOrderSource(OrderSourceType.ECOMMERCE);
+		CustomerInfo cust = new CustomerInfo();
+		cust.setAccountUsername("Woolfoo");
+		cust.setUserAccountNumber("123456ATY");
+		cust.setUserAccountEmail("woolfoo@gmail.com");
+		cust.setMembershipId("Member01");
+		cust.setMembershipPhone("9765431234");
+		cust.setMembershipEmail("mem@abc.com");
+		cust.setMembershipName("memName");
+		Calendar createDate = Calendar.getInstance();
+		createDate.set(1990, Calendar.MARCH, 16);
+		cust.setAccountCreatedDate(createDate);
+		cust.setUserAccountPhone("123456789");
+		sale.setCustomerInfo(cust);
+		CardType card = new CardType();
+		card.setNumber("4100000000000000");
+		card.setExpDate("1215");
+		card.setType(MethodOfPaymentTypeEnum.VI);
+		sale.setCard(card);
+		SaleResponse response = cnp.sale(sale);
+		assertEquals(response.getMessage(), "Approved", response.getMessage());
+		assertEquals("sandbox", response.getLocation());
+	}
+
+	@Test
+	public void testSaleWithEnhancedDataLineItemDataOrdChanelfraudCheckStatusBussinessIndiCrypto() throws Exception {
+		Sale sale = new Sale();
+		sale.setId("12345");
+		sale.setReportGroup("Default");
+		sale.setOrderId("67890");
+		sale.setAmount(10000L);
+		sale.setOrderSource(OrderSourceType.ECOMMERCE);
+		CardType card = new CardType();
+		card.setNumber("4100000000000000");
+		card.setExpDate("1215");
+		card.setType(MethodOfPaymentTypeEnum.VI);
+		sale.setCard(card);
+		EnhancedData enhanced = new EnhancedData();
+		enhanced.setCustomerReference("Cust Ref");
+		enhanced.setSalesTax(1000L);
+		LineItemData lid = new LineItemData();
+		lid.setItemSequenceNumber(1);
+		lid.setItemDescription("Electronics");
+		lid.setProductCode("El01");
+		lid.setItemCategory("Ele Appiances");
+		lid.setItemSubCategory("home appliaces");
+		lid.setProductId("1001");
+		lid.setProductName("dryer");
+		enhanced.getLineItemDatas().add(lid);
+		enhanced.setDiscountCode("oneTimeDis");
+		enhanced.setDiscountPercent(BigInteger.valueOf(12));
+		enhanced.setFulfilmentMethodType(FulfilmentMethodTypeEnum.COUNTER_PICKUP);
+		sale.setEnhancedData(enhanced);
+		sale.setBusinessIndicator(BusinessIndicatorEnum.HIGH_RISK_SECURITIES_PURCHASE);
+		sale.setOrderChannel(OrderChannelEnum.IN_STORE_KIOSK);
+		sale.setFraudCheckStatus("CLOSE");
+		sale.setCrypto(true);
+		SaleResponse response = cnp.sale(sale);
+		assertEquals(response.getMessage(), "Approved", response.getMessage());
+		assertEquals("sandbox", response.getLocation());
+	}
+
+	@Test
+	public void testSaleWithAdditionalCOFData() throws Exception {
+		Sale sale = new Sale();
+		sale.setId("12345");
+		sale.setReportGroup("Default");
+		sale.setOrderId("67890");
+		sale.setAmount(10000L);
+		sale.setOrderSource(OrderSourceType.ECOMMERCE);
+		CardType card = new CardType();
+		card.setNumber("4100000000000000");
+		card.setExpDate("1215");
+		card.setType(MethodOfPaymentTypeEnum.VI);
+		sale.setCard(card);
+		AdditionalCOFData data = new AdditionalCOFData();
+		data.setUniqueId("56655678D");
+		data.setTotalPaymentCount("35");
+		data.setFrequencyOfMIT(FrequencyOfMITEnum.ANNUALLY);
+		data.setPaymentType(PaymentTypeEnum.FIXED_AMOUNT);
+		data.setValidationReference("asd123");
+		data.setSequenceIndicator(BigInteger.valueOf(12));
+		sale.setAdditionalCOFData(data);
+		SaleResponse response = cnp.sale(sale);
+		assertEquals(response.getMessage(), "Approved", response.getMessage());
+		assertEquals("sandbox", response.getLocation());
+	}
+	@Test
+	public void simpleSaleWithRetailerAddress() throws Exception{
+		Sale sale = new Sale();
+		sale.setAmount(106L);
+		sale.setCnpTxnId(123456L);
+		sale.setOrderId("12344");
+		sale.setOrderSource(OrderSourceType.ECOMMERCE);
+		CardType card = new CardType();
+		card.setType(MethodOfPaymentTypeEnum.VI);
+		card.setNumber("4100000000000000");
+		card.setExpDate("1210");
+		sale.setCard(card);
+		sale.setId("id");
+		Contact contact = new Contact();
+		contact.setSellerId("12386576");
+		contact.setCompanyName("fis Global");
+		contact.setAddressLine1("Pune East");
+		contact.setAddressLine2("Pune west");
+		contact.setAddressLine3("Pune north");
+		contact.setCity("lowell");
+		contact.setState("MA");
+		contact.setZip("825320");
+		contact.setCountry(CountryTypeEnum.IN);
+		contact.setEmail("cnp.com");
+		contact.setPhone("8880129170");
+		contact.setUrl("www.lowel.com");
+		sale.setRetailerAddress(contact);
 		SaleResponse response = cnp.sale(sale);
 		assertEquals("Approved", response.getMessage());
 		assertEquals("sandbox", response.getLocation());

--- a/src/main/java/io/github/vantiv/sdk/Versions.java
+++ b/src/main/java/io/github/vantiv/sdk/Versions.java
@@ -2,7 +2,7 @@ package io.github.vantiv.sdk;
 
 public class Versions {
 
-    public static final String XML_VERSION="12.22";
-    public static final String SDK_VERSION="Java;12.22.0";
+    public static final String XML_VERSION="12.24";
+    public static final String SDK_VERSION="Java;12.24.0";
 
 }

--- a/src/main/xsd/cnpBatch_v12.24.xsd
+++ b/src/main/xsd/cnpBatch_v12.24.xsd
@@ -2,7 +2,7 @@
 <xs:schema targetNamespace="http://www.vantivcnp.com/schema" xmlns:xs="http://www.w3.org/2001/XMLSchema"
            xmlns:xp="http://www.vantivcnp.com/schema" elementFormDefault="qualified" attributeFormDefault="unqualified">
 
-    <xs:include schemaLocation="cnpTransaction_v12.22.xsd" />
+    <xs:include schemaLocation="cnpTransaction_v12.24.xsd" />
 
     <xs:element name="cnpRequest">
         <xs:complexType>

--- a/src/main/xsd/cnpCommon_v12.24.xsd
+++ b/src/main/xsd/cnpCommon_v12.24.xsd
@@ -53,6 +53,12 @@
         </xs:restriction>
     </xs:simpleType>
 
+    <xs:simpleType name="string14Type">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="14" />
+        </xs:restriction>
+    </xs:simpleType>
+
     <xs:simpleType name="stringExactly4Type">
         <xs:restriction base="xs:string">
             <xs:minLength value="4" />
@@ -87,6 +93,18 @@
     <xs:simpleType name="string64Type">
         <xs:restriction base="xs:string">
             <xs:maxLength value="64" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="string100Type">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="100" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="string150Type">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="150" />
         </xs:restriction>
     </xs:simpleType>
 
@@ -211,12 +229,22 @@
     <xs:simpleType name="businessIndicatorEnum">
         <xs:restriction base="xs:string">
             <xs:enumeration value="consumerBillPayment" />
+            <xs:enumeration value="buyOnlinePickUpInStore" />
+            <xs:enumeration value="highRiskSecuritiesPurchase" />
+            <xs:enumeration value="fundTransfer" />
+            <xs:enumeration value="walletTransfer" />
         </xs:restriction>
     </xs:simpleType>
 
     <xs:simpleType name="transactionAmountType">
         <xs:restriction base="xs:integer">
             <xs:totalDigits value="12" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="discountPercentType">
+        <xs:restriction base="xs:integer">
+            <xs:totalDigits value="8" />
         </xs:restriction>
     </xs:simpleType>
 
@@ -612,6 +640,12 @@
         </xs:restriction>
     </xs:simpleType>
 
+    <xs:simpleType name="sellerIdType">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="20" />
+        </xs:restriction>
+    </xs:simpleType>
+
     <xs:simpleType name="lastNameType">
         <xs:restriction base="xs:string">
             <xs:maxLength value="25" />
@@ -664,10 +698,14 @@
                 </xs:simpleType>
             </xs:element>
             <xs:element name="phone" type="xp:phoneType" minOccurs="0" />
+            <xs:element name="sellerId" type="xp:sellerIdType" minOccurs="0" />
+            <xs:element name="url" type="xp:string35Type" minOccurs="0"/>
         </xs:all>
     </xs:complexType>
 
     <xs:element name="billToAddress" type="xp:contact" />
+
+    <xs:element name="retailerAddress" type="xp:contact" />
 
     <xs:complexType name="address">
         <xs:all>
@@ -895,6 +933,12 @@
         </xs:restriction>
     </xs:simpleType>
 
+    <xs:simpleType name="string35Type">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="35" />
+        </xs:restriction>
+    </xs:simpleType>
+
     <xs:simpleType name="stringExactly16AlphanumericType">
         <xs:restriction base="xs:string">
             <xs:pattern value="[A-Z,a-z,0-9]{16,16}"/>
@@ -914,6 +958,12 @@
     </xs:simpleType>
 
     <xs:simpleType name="noOfAdultsType">
+        <xs:restriction base="xs:integer">
+            <xs:totalDigits value="2" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="sequenceIndicatorType">
         <xs:restriction base="xs:integer">
             <xs:totalDigits value="2" />
         </xs:restriction>
@@ -950,6 +1000,60 @@
         <xs:restriction base="xs:string">
             <xs:enumeration value="Y" />
             <xs:enumeration value="N" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="additionalCOFData">
+        <xs:all>
+            <xs:element name="totalPaymentCount" type="xp:string2Type" minOccurs="0" />
+            <xs:element name="paymentType" type="xp:paymentTypeEnum" minOccurs="0" />
+            <xs:element name="uniqueId" type="xp:string14Type" minOccurs="0" />
+            <xs:element name="frequencyOfMIT" type="xp:frequencyOfMITEnum" minOccurs="0" />
+            <xs:element name="validationReference" type="xp:string20Type" minOccurs="0" />
+            <xs:element name="sequenceIndicator" type="xp:sequenceIndicatorType" minOccurs="0" />
+        </xs:all>
+    </xs:complexType>
+
+    <xs:element name="additionalCOFData" type="xp:additionalCOFData" />
+
+    <xs:simpleType name="paymentTypeEnum">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="Fixed Amount" />
+            <xs:enumeration value="Variable Amount" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="frequencyOfMITEnum">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="Daily" />
+            <xs:enumeration value="Weekly" />
+            <xs:enumeration value="BiWeekly" />
+            <xs:enumeration value="Monthly" />
+            <xs:enumeration value="Quarterly" />
+            <xs:enumeration value="BiAnnually" />
+            <xs:enumeration value="Anually" /> <!--Incorrect spelling. deprecated field-->
+            <xs:enumeration value="Annually" />
+            <xs:enumeration value="UNSCHEDULED" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="fulfilmentMethodTypeEnum">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="DELIVERY"/>
+            <xs:enumeration value="COUNTER_PICKUP"/>
+            <xs:enumeration value="CURBSIDE_PICKUP"/>
+            <xs:enumeration value="LOCKER_PICKUP"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="orderChannelEnum">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="WEB" />
+            <xs:enumeration value="PHONE" />
+            <xs:enumeration value="MOBILE_APP" />
+            <xs:enumeration value="SOCIAL" />
+            <xs:enumeration value="MARKETPLACE" />
+            <xs:enumeration value="IN_STORE_KIOSK" />
         </xs:restriction>
     </xs:simpleType>
 

--- a/src/main/xsd/cnpOnline_v12.24.xsd
+++ b/src/main/xsd/cnpOnline_v12.24.xsd
@@ -3,7 +3,7 @@
 <xs:schema targetNamespace="http://www.vantivcnp.com/schema" xmlns:xp="http://www.vantivcnp.com/schema"
            xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="unqualified">
 
-    <xs:include schemaLocation="cnpTransaction_v12.22.xsd" />
+    <xs:include schemaLocation="cnpTransaction_v12.24.xsd" />
 
     <xs:complexType name="baseRequest">
         <xs:sequence>
@@ -66,6 +66,8 @@
                         <xs:element name="message" type="xp:messageType" />
                         <xs:element name="location" type="xs:string" minOccurs="0"/>
                         <xs:element name="recyclingResponse" type="xp:voidRecyclingResponseType" minOccurs="0" />
+                        <!-- Introduced as part of Guaranteed Payments -->
+                        <xs:element name="checkoutId" type="xp:string256Type" minOccurs="0" />
                     </xs:all>
 
                 </xs:extension>
@@ -102,6 +104,8 @@
                         <xs:element name="postDate" type="xs:date" />
                         <xs:element name="message" type="xp:messageType" />
                         <xs:element name="location" type="xs:string" minOccurs="0"/>
+                        <!-- Introduced as part of Guaranteed Payments -->
+                        <xs:element name="checkoutId" type="xp:string256Type" minOccurs="0" />
                     </xs:all>
                 </xs:extension>
             </xs:complexContent>
@@ -424,3 +428,4 @@
     </xs:element>
 -->
 </xs:schema>
+

--- a/src/main/xsd/cnpRecurring_v12.24.xsd
+++ b/src/main/xsd/cnpRecurring_v12.24.xsd
@@ -1,7 +1,8 @@
+
 <xs:schema targetNamespace="http://www.vantivcnp.com/schema" xmlns:xp="http://www.vantivcnp.com/schema"
            xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="unqualified">
 
-    <xs:include schemaLocation="cnpCommon_v12.22.xsd" />
+    <xs:include schemaLocation="cnpCommon_v12.24.xsd" />
 
     <xs:element name="recurringTransaction" type="xp:recurringTransactionType" abstract="true" />
     <xs:element name="recurringTransactionResponse" type="xp:recurringTransactionResponseType" abstract="true" />

--- a/src/main/xsd/cnpTransaction_v12.24.xsd
+++ b/src/main/xsd/cnpTransaction_v12.24.xsd
@@ -1,8 +1,8 @@
 <xs:schema targetNamespace="http://www.vantivcnp.com/schema" xmlns:xp="http://www.vantivcnp.com/schema"
            xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="unqualified">
 
-    <xs:include schemaLocation="cnpCommon_v12.22.xsd" />
-    <xs:include schemaLocation="cnpRecurring_v12.22.xsd" />
+    <xs:include schemaLocation="cnpCommon_v12.24.xsd" />
+    <xs:include schemaLocation="cnpRecurring_v12.24.xsd" />
 
     <xs:element name="transaction" type="xp:transactionType" abstract="true" />
 
@@ -105,6 +105,15 @@
                         </xs:restriction>
                     </xs:simpleType>
                 </xs:element>
+                <xs:element name="accountUsername" type="xp:string100Type" minOccurs="0" />
+                <xs:element name="userAccountNumber" type="xp:string100Type" minOccurs="0" />
+                <xs:element name="userAccountEmail" type="xp:emailType" minOccurs="0" />
+                <xs:element name="membershipId" type="xp:string100Type" minOccurs="0" />
+                <xs:element name="membershipPhone" type="xp:phoneType" minOccurs="0" />
+                <xs:element name="membershipEmail" type="xp:emailType" minOccurs="0" />
+                <xs:element name="membershipName" type="xp:string100Type" minOccurs="0" />
+                <xs:element name="accountCreatedDate" type="xs:date" minOccurs="0" />
+                <xs:element name="userAccountPhone" type="xp:phoneType" minOccurs="0" />
             </xs:all>
         </xs:complexType>
     </xs:element>
@@ -137,6 +146,8 @@
                             <xs:element ref="xp:customerInfo" minOccurs="0" />
                             <xs:element ref="xp:billToAddress" minOccurs="0" />
                             <xs:element ref="xp:shipToAddress" minOccurs="0" />
+                            <xs:element ref="xp:retailerAddress" minOccurs="0" />
+                            <xs:element ref="xp:additionalCOFData" minOccurs="0" />
                             <xs:choice>
                                 <xs:element name="mpos" type="xp:mposType" />
                                 <xs:element name="card" type="xp:cardType" />
@@ -169,6 +180,10 @@
                             <xs:element name="skipRealtimeAU" type="xs:boolean" minOccurs="0" />
                             <xs:element name="merchantCategoryCode" type="xp:stringExactly4Type" minOccurs="0" />
                             <xs:element name="businessIndicator" type="xp:businessIndicatorEnum" minOccurs="0" />
+                            <xs:element name="orderChannel" type="xp:orderChannelEnum" minOccurs="0">
+                            </xs:element>
+                            <xs:element name="fraudCheckStatus" type="xp:string50Type" minOccurs="0"/>
+                            <xs:element name="crypto" type="xs:boolean" minOccurs="0" />
                         </xs:sequence>
                     </xs:choice>
                 </xs:extension>
@@ -296,6 +311,8 @@
                         <xs:element name="orderSource" type="xp:orderSourceType" />
                         <xs:element ref="xp:billToAddress" minOccurs="0" />
                         <xs:element ref="xp:shipToAddress" minOccurs="0" />
+                        <xs:element ref="xp:retailerAddress" minOccurs="0" />
+                        <xs:element ref="xp:additionalCOFData" minOccurs="0" />
                         <xs:choice>
                             <xs:element name="mpos" type="xp:mposType" />
                             <xs:element name="card" type="xp:cardType" />
@@ -315,6 +332,7 @@
                         <xs:element name="originalTransactionAmount" type="xp:transactionAmountType" minOccurs="0" />
                         <xs:element name="merchantCategoryCode" type="xp:stringExactly4Type" minOccurs="0" />
                         <xs:element name="businessIndicator" type="xp:businessIndicatorEnum" minOccurs="0" />
+                        <xs:element name="crypto" type="xs:boolean" minOccurs="0" />
                     </xs:sequence>
                 </xs:extension>
             </xs:complexContent>
@@ -336,6 +354,8 @@
                         <xs:element ref="xp:customerInfo" minOccurs="0" />
                         <xs:element ref="xp:billToAddress" minOccurs="0" />
                         <xs:element ref="xp:shipToAddress" minOccurs="0" />
+                        <xs:element ref="xp:retailerAddress" minOccurs="0" />
+                        <xs:element ref="xp:additionalCOFData" minOccurs="0" />
                         <xs:choice>
                             <xs:element name="mpos" type="xp:mposType" />
                             <xs:element name="card" type="xp:cardType" />
@@ -380,6 +400,9 @@
                         <xs:element name="skipRealtimeAU" type="xs:boolean" minOccurs="0" />
                         <xs:element name="merchantCategoryCode" type="xp:stringExactly4Type" minOccurs="0" />
                         <xs:element name="businessIndicator" type="xp:businessIndicatorEnum" minOccurs="0" />
+                        <xs:element name="orderChannel" type="xp:orderChannelEnum" minOccurs="0"/>
+                        <xs:element name="fraudCheckStatus" type="xp:string50Type" minOccurs="0"/>
+                        <xs:element name="crypto" type="xs:boolean" minOccurs="0" />
                     </xs:sequence>
                 </xs:extension>
             </xs:complexContent>
@@ -624,6 +647,9 @@
                 <xs:element name="orderDate" type="xs:date" minOccurs="0" />
                 <xs:element ref="xp:detailTax" minOccurs="0" maxOccurs="6" />
                 <xs:element ref="xp:lineItemData" minOccurs="0" maxOccurs="99" />
+                <xs:element name="discountCode" type="xp:string100Type" minOccurs="0" />
+                <xs:element name="discountPercent" type="xp:discountPercentType" minOccurs="0" />
+                <xs:element name="fulfilmentMethodType" type="xp:fulfilmentMethodTypeEnum" minOccurs="0"/>
             </xs:sequence>
         </xs:complexType>
     </xs:element>
@@ -657,6 +683,10 @@
                 <xs:element name="commodityCode" type="xp:commodityCodeType" minOccurs="0" />
                 <xs:element name="unitCost" type="xp:unitCostType" minOccurs="0" />
                 <xs:element ref="xp:detailTax" minOccurs="0" maxOccurs="6" />
+                <xs:element name="itemCategory" type="xp:string100Type" minOccurs="0" />
+                <xs:element name="itemSubCategory" type="xp:string100Type" minOccurs="0" />
+                <xs:element name="productId" type="xp:string150Type" minOccurs="0" />
+                <xs:element name="productName" type="xp:string150Type" minOccurs="0"/>
             </xs:sequence>
         </xs:complexType>
     </xs:element>
@@ -838,6 +868,8 @@
                         <xs:element name="paymentAccountReferenceNumber" type="xp:string50Type" minOccurs="0" />
                         <!-- If PRIME PINless debit transaction -->
                         <xs:element ref="xp:pinlessDebitResponse" minOccurs="0"/>
+                        <!-- Introduced as part of Guaranteed Payments -->
+                        <xs:element name="checkoutId" type="xp:string256Type" minOccurs="0" />
                     </xs:all>
                 </xs:extension>
             </xs:complexContent>
@@ -1013,6 +1045,8 @@
                         <xs:element name="location" type="xs:string" minOccurs="0"/>
                         <!-- If PRIME PINless debit transaction -->
                         <xs:element ref="xp:pinlessDebitResponse" minOccurs="0"/>
+                        <!-- Introduced as part of Guaranteed Payments -->
+                        <xs:element name="checkoutId" type="xp:string256Type" minOccurs="0" />
                     </xs:all>
                 </xs:extension>
             </xs:complexContent>
@@ -1176,6 +1210,8 @@
                         <xs:element ref="xp:fraudResult" minOccurs="0" />
                         <!-- If PRIME PINless debit transaction -->
                         <xs:element ref="xp:pinlessDebitResponse" minOccurs="0"/>
+                        <!-- Introduced as part of Guaranteed Payments -->
+                        <xs:element name="checkoutId" type="xp:string256Type" minOccurs="0" />
                     </xs:all>
                 </xs:extension>
             </xs:complexContent>
@@ -1221,6 +1257,8 @@
                         <!-- If Gift Card transaction -->
                         <xs:element ref="xp:fraudResult" minOccurs="0" />
                         <xs:element ref="xp:giftCardResponse" minOccurs="0"/>
+                        <!-- Introduced as part of Guaranteed Payments -->
+                        <xs:element name="checkoutId" type="xp:string256Type" minOccurs="0" />
                     </xs:all>
                 </xs:extension>
             </xs:complexContent>
@@ -1244,6 +1282,8 @@
                         <!-- If Gift Card transaction -->
                         <xs:element ref="xp:fraudResult" minOccurs="0" />
                         <xs:element ref="xp:giftCardResponse" minOccurs="0"/>
+                        <!-- Introduced as part of Guaranteed Payments -->
+                        <xs:element name="checkoutId" type="xp:string256Type" minOccurs="0" />
                     </xs:all>
                 </xs:extension>
             </xs:complexContent>
@@ -1292,6 +1332,8 @@
                         <!-- If PRIME PINless debit transaction -->
                         <xs:element ref="xp:pinlessDebitResponse" minOccurs="0"/>
                         <xs:element name="paymentAccountReferenceNumber" type="xp:string50Type" minOccurs="0" />
+                        <!-- Introduced as part of Guaranteed Payments -->
+                        <xs:element name="checkoutId" type="xp:string256Type" minOccurs="0" />
                     </xs:all>
                 </xs:extension>
             </xs:complexContent>
@@ -1314,6 +1356,8 @@
                         <xs:element name="tokenResponse" type="xp:tokenResponseType" minOccurs="0"/>
                         <!-- If Gift Card transaction -->
                         <xs:element ref="xp:fraudResult" minOccurs="0" />
+                        <!-- Introduced as part of Guaranteed Payments -->
+                        <xs:element name="checkoutId" type="xp:string256Type" minOccurs="0" />
                     </xs:all>
                 </xs:extension>
             </xs:complexContent>
@@ -1574,6 +1618,8 @@
                         <xs:element name="postDate" type="xs:date" minOccurs="0" />
                         <xs:element ref="xp:accountUpdater" minOccurs="0" />
                         <xs:element name="tokenResponse" type="xp:tokenResponseType" minOccurs="0"/>
+                        <!-- Introduced as part of Guaranteed Payments -->
+                        <xs:element name="checkoutId" type="xp:string256Type" minOccurs="0" />
                     </xs:all>
                 </xs:extension>
             </xs:complexContent>
@@ -1594,6 +1640,8 @@
                         <xs:element name="postDate" type="xs:date" minOccurs="0" />
                         <xs:element ref="xp:accountUpdater" minOccurs="0" />
                         <xs:element name="tokenResponse" type="xp:tokenResponseType" minOccurs="0"/>
+                        <!-- Introduced as part of Guaranteed Payments -->
+                        <xs:element name="checkoutId" type="xp:string256Type" minOccurs="0" />
                     </xs:all>
                 </xs:extension>
             </xs:complexContent>
@@ -2703,7 +2751,7 @@
                         <xs:sequence>
                             <xs:choice>
                                 <xs:element name="fundingCustomerId" type="xp:merchantIdentificationType" minOccurs="0"/>
-                                <xs:element name="fundingSubmerchantId" type="xp:merchantIdentificationType" minOccurs="0"/>
+                                <xs:element name="fundingSubmerchantId" type="xp:merchantIdentificationType" minOccurs="0" />
                             </xs:choice>
                             <xs:choice>
                                 <xs:element name="customerName" type="xp:string256Type"/>


### PR DESCRIPTION
* Change: [cnpAPI v12.23] Added a new value in businessIndicatorEnum to support businessIndicator element :buyOnlinePickUpInStore.
* Change: [cnpAPI v12.23] Added  new element :orderChannel for Auth/sale transaction request.
* Change: [cnpAPI v12.23] Added new elements(accountUsername, userAccountNumber, userAccountEmail, membershipId, membershipPhone, membershipEmail, membershipName, accountCreatedDate and userAccountPhone) in customerInfo type.
* Change: [cnpAPI v12.23] Added new elements:sellerId , url to support contact type which is referenced by retailerAddress
* Change: [cnpAPI v12.23] Added new elements retailerAddress,additionalCOFData to support Auth/Sale/CaptureGivenAuth.
* Change: [cnpAPI v12.23] Added a new elements:discountCode,discountPercent,fulfilmentMethodType in enhancedData.
* Change: [cnpAPI v12.23] Added a new elements:itemCategory,itemSubCategory,productId,productName in LineItemData
* Change: [cnpAPI v12.24] Added a new values in businessIndicatorEnum to support businessIndicator element :highRiskSecuritiesPurchase,fundTransfer,walletTransfer
* Change: [cnpAPI v12.24] Added OrderChannelEnum to support  element :orderChannel for Auth/sale transaction request.
* Change: [cnpAPI v12.24] Added fulfilmentMethodTypeEnum to support  element fulfilmentMethodType in enhancedData type
* Change: [cnpAPI v12.24] Added new value in frequencyOfMITEnum: Annually(It was Anually- Incorrect spelling in earlier version.)
* Change: [cnpAPI v12.24] Added new element crypto to support Auth/Sale/CaptureGivenAuth.
* Change: [cnpAPI v12.24] Added new element fraudCheckStatus to support Auth/Sale.