### PR TITLE
Java SDK upgrade12.34

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,14 @@
 = Vantiv eCommerce CNP CHANGELOG
 
+==Version 12.34.0 (v12.34)(Feb 15, 2024)
+* Change: [cnpAPI v12.34] For existing simple element 'amount' simple type is changed from 'transactionAmountType' to 'achTransactionAmountType' in transactions- vendorCredit,vendorDebit,submerchantCredit,submerchantDebit,payFacDebit,payFacCredit,reserveCredit,reserveDebit
+* Change: [cnpAPI v12.34] Added new simple type 'achTransactionAmountType' to support 'amount'.
+* Change: [cnpAPI v12.34] Added 'accountToAccount','bankInitiated','fundsDisbursement','payrollDisbursement','personToPerson','topUp' in existing enum businessIndicatorEnum.
+* Change: [cnpAPI v12.34] For existing element 'origId' from 'queryTransaction' simpletype changed from 'string25Type' to 'stringMin1Max36CollapseWhiteSpaceType'.
+* Change: [cnpAPI v12.34] New request element 'finicityUrlRequest' is added with subfeilds-'firstName','lastName','phoneNumber','email'.
+* Change: [cnpAPI v12.34] New response element 'finicityUrlResponse' is added with subfeilds-'cnpTxnId','response','responseTime','message','location','echeckCustomerId','url'.
+* Change: [cnpAPI v12.34] New simple element 'echeckCustomerId' is added existing complex type 'echeckType'.
+
 ==Version 12.33.0 (v12.32 & v12.33)(Dec 7, 2023)
 * Change: [cnpAPI v12.32] simple types of customerIpAddress is changed from ipAddress to stringipAddress
 * Change: [cnpAPI v12.32] to support  customerIpAddress new simple type stringipAddress is added

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 DIST_DIR_15=build/dist/java15
-JAR_VERSION=12.33.0
+JAR_VERSION=12.34.0
 KIT_DIR=build/kit/java15
 KIT_DEPENDENCIES_DIR=build/kit/java15/dependencies
 OPENSFTP_DIR=lib/opensftp-0.3.0
-SCHEMA_VERSION=12.33
+SCHEMA_VERSION=12.34

--- a/src/functionalTest/java/io/github/vantiv/sdk/TestAuth.java
+++ b/src/functionalTest/java/io/github/vantiv/sdk/TestAuth.java
@@ -1029,4 +1029,24 @@ public class TestAuth {
 		assertEquals("sandbox", response.getLocation());
 	}
 
+	@Test
+	public void simpleAuthWithBusinessIndcatorEnum() throws Exception {
+		Authorization authorization = new Authorization();
+		authorization.setReportGroup("Planets");
+		authorization.setOrderId("12344");
+		authorization.setAmount(106L);
+		authorization.setOrderSource(OrderSourceType.ECOMMERCE);
+		authorization.setId("id");
+		CardType card = new CardType();
+		card.setType(MethodOfPaymentTypeEnum.VI);
+		card.setNumber("4100000000000000");
+		card.setExpDate("1210");
+		authorization.setCard(card);
+		authorization.setBusinessIndicator(BusinessIndicatorEnum.TOP_UP);
+		AuthorizationResponse response = cnp.authorize(authorization);
+		assertEquals(response.getMessage(), "000",response.getResponse());
+		assertEquals("Approved", response.getMessage());
+		assertEquals("sandbox", response.getLocation());
+	}
+
 }

--- a/src/functionalTest/java/io/github/vantiv/sdk/TestEcheckCredit.java
+++ b/src/functionalTest/java/io/github/vantiv/sdk/TestEcheckCredit.java
@@ -151,5 +151,30 @@ public class TestEcheckCredit {
 		assertEquals("sandbox", response.getLocation());
     }
 
+	@Test
+	public void echeckCreditWithEcheckCustId() throws Exception{
+		EcheckCredit echeckcredit = new EcheckCredit();
+		echeckcredit.setAmount(12L);
+		echeckcredit.setOrderId("12345");
+		echeckcredit.setOrderSource(OrderSourceType.ECOMMERCE);
+		EcheckType echeck = new EcheckType();
+		echeck.setAccType(EcheckAccountTypeEnum.CHECKING);
+		echeck.setAccNum("12345657890");
+		echeck.setRoutingNum("123456789");
+		echeck.setCheckNum("123455");
+		echeck.setEcheckCustomerId("22345678");
+		echeckcredit.setEcheck(echeck);
+		Contact billToAddress = new Contact();
+		billToAddress.setName("Bob");
+		billToAddress.setCity("Lowell");
+		billToAddress.setState("MA");
+		billToAddress.setEmail("cnp.com");
+		echeckcredit.setBillToAddress(billToAddress);
+		echeckcredit.setId("id");
+		EcheckCreditResponse response = cnp.echeckCredit(echeckcredit);
+		assertEquals("Approved", response.getMessage());
+		assertEquals("sandbox", response.getLocation());
+	}
+
 }
 

--- a/src/functionalTest/java/io/github/vantiv/sdk/TestEcheckSale.java
+++ b/src/functionalTest/java/io/github/vantiv/sdk/TestEcheckSale.java
@@ -263,5 +263,34 @@ public class TestEcheckSale {
         }
     }
 
+	@Test
+	public void echeckSaleWithEcheckCustId() throws Exception {
+		EcheckSale echecksale = new EcheckSale();
+		echecksale.setReportGroup("2403");
+		echecksale.setAmount(123456L);
+		echecksale.setVerify(true);
+		echecksale.setOrderId("TC7002_1.1ECSaleOnline");
+		echecksale.setOrderSource(OrderSourceType.TELEPHONE);
+		EcheckType echeck = new EcheckType();
+		echeck.setAccType(EcheckAccountTypeEnum.SAVINGS);
+		echeck.setAccNum("1099999902");
+		echeck.setRoutingNum("114567895");
+		echeck.setCheckNum("924");
+		echeck.setEcheckCustomerId("12345678");
+
+		echecksale.setEcheck(echeck);
+		Contact contact = new Contact();
+		contact.setName("Bob");
+		contact.setCity("lowell");
+		contact.setState("MA");
+		contact.setEmail("cnp.com");
+		echecksale.setBillToAddress(contact);
+		echecksale.setShipToAddress(contact);
+		echecksale.setId("id");
+		EcheckSalesResponse response = cnp.echeckSale(echecksale);
+		assertEquals("Approved", response.getMessage());
+		assertEquals("sandbox", response.getLocation());
+	}
+
 }
 

--- a/src/functionalTest/java/io/github/vantiv/sdk/TestFinicityUrlRequest.java
+++ b/src/functionalTest/java/io/github/vantiv/sdk/TestFinicityUrlRequest.java
@@ -1,0 +1,33 @@
+package io.github.vantiv.sdk;
+
+import io.github.vantiv.sdk.generate.*;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class TestFinicityUrlRequest {
+
+    private static CnpOnline cnp;
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        cnp = new CnpOnline();
+    }
+
+    @Test
+    public void simpleFinicityUrlRequest() throws Exception {
+        FinicityUrlRequest request = new FinicityUrlRequest();
+        request.setId("url1");
+        request.setReportGroup("XML10Mer1");
+        request.setCustomerId("154646587");
+        request.setFirstName("John");
+        request.setLastName("Smith");
+        request.setPhoneNumber("1-801-984-4200");
+        request.setEmail("myname@mycompany.com");
+        FinicityUrlResponse response = cnp.finicityUrl(request);
+        assertEquals(response.getMessage(), "000",response.getResponse());
+        assertEquals("Approved", response.getMessage());
+        assertEquals("sandbox", response.getLocation());
+    }
+}

--- a/src/functionalTest/java/io/github/vantiv/sdk/TestPayFac.java
+++ b/src/functionalTest/java/io/github/vantiv/sdk/TestPayFac.java
@@ -1,0 +1,61 @@
+package io.github.vantiv.sdk;
+
+import io.github.vantiv.sdk.generate.*;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class TestPayFac {
+
+    private static CnpOnline cnp;
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        cnp = new CnpOnline();
+    }
+
+    @Test
+    public void testPayFacCredit() throws Exception {
+        PayFacCredit payfac = new PayFacCredit();
+        payfac.setReportGroup("payFacCredit");
+        payfac.setId("111");
+        payfac.setFundingSubmerchantId("2345016400556org1200");
+        payfac.setFundsTransferId("1201b");
+        payfac.setAmount(1000L);
+        PayFacCreditResponse response = cnp.payFacCredit(payfac);
+        assertEquals("Approved", response.getMessage());
+        assertEquals("sandbox", response.getLocation());
+    }
+
+    @Test
+    public void testPayFacDebit() throws Exception {
+        PayFacDebit payfac = new PayFacDebit();
+        payfac.setReportGroup("payFacDebit");
+        payfac.setId("112");
+        payfac.setFundingSubmerchantId("2345016400556org1200");
+        payfac.setFundsTransferId("1201a");
+        payfac.setAmount(1000L);
+        PayFacDebitResponse response = cnp.payFacDebit(payfac);
+        assertEquals("Approved", response.getMessage());
+        assertEquals("sandbox", response.getLocation());
+    }
+
+    @Test
+    public void testPayFacCreditAmountNegative() throws Exception {
+        try {
+            PayFacCredit payfac = new PayFacCredit();
+            payfac.setReportGroup("payFacCredit");
+            payfac.setId("111");
+            payfac.setFundingSubmerchantId("2345016400556org1200");
+            payfac.setFundsTransferId("1201b");
+            payfac.setAmount(99999999999L); // invalid amount value, number of total digits has been limited to 10.
+            PayFacCreditResponse response = cnp.payFacCredit(payfac);
+            assertEquals("payFacCredit",response.getReportGroup());
+        }
+        catch(CnpOnlineException e) {
+            assertTrue(e.getMessage(), e.getMessage().startsWith("Error validating xml data against the schema"));
+        }
+    }
+}

--- a/src/main/java/io/github/vantiv/sdk/CnpOnline.java
+++ b/src/main/java/io/github/vantiv/sdk/CnpOnline.java
@@ -877,6 +877,21 @@ public class CnpOnline {
         return (PayoutOrgDebitResponse)newresponse.getValue();
     }
 
+    public FinicityUrlResponse finicityUrl(FinicityUrlRequest finicityUrl) throws CnpOnlineException {
+        CnpOnlineRequest request = createCnpOnlineRequest();
+        return finicityUrl(finicityUrl, request);
+    }
+
+    public FinicityUrlResponse finicityUrl(FinicityUrlRequest finicityUrl, CnpOnlineRequest overrides) throws CnpOnlineException {
+        CnpOnlineRequest request = fillInMissingFieldsFromConfig(overrides);
+        fillInReportGroup(finicityUrl);
+
+        request.setTransaction(CnpContext.getObjectFactory().createFinicityUrlRequest(finicityUrl));
+        CnpOnlineResponse response = sendToCnp(request);
+        JAXBElement<? extends TransactionTypeWithReportGroup> newresponse = response.getTransactionResponse();
+        return (FinicityUrlResponse)newresponse.getValue();
+    }
+
 	private CnpOnlineRequest createCnpOnlineRequest() {
 		CnpOnlineRequest request = new CnpOnlineRequest();
 		request.setMerchantId(config.getProperty("merchantId"));

--- a/src/main/java/io/github/vantiv/sdk/Versions.java
+++ b/src/main/java/io/github/vantiv/sdk/Versions.java
@@ -2,6 +2,6 @@ package io.github.vantiv.sdk;
 
 public class Versions {
 
-    public static final String XML_VERSION="12.33";
-    public static final String SDK_VERSION="Java;12.33.0";
+    public static final String XML_VERSION="12.34";
+    public static final String SDK_VERSION="Java;12.34.0";
 }

--- a/src/main/xsd/cnpBatch_v12.34.xsd
+++ b/src/main/xsd/cnpBatch_v12.34.xsd
@@ -2,7 +2,7 @@
 <xs:schema targetNamespace="http://www.vantivcnp.com/schema" xmlns:xs="http://www.w3.org/2001/XMLSchema"
            xmlns:xp="http://www.vantivcnp.com/schema" elementFormDefault="qualified" attributeFormDefault="unqualified">
 
-    <xs:include schemaLocation="cnpTransaction_v12.33.xsd" />
+    <xs:include schemaLocation="cnpTransaction_v12.34.xsd" />
 
     <xs:element name="cnpRequest">
         <xs:complexType>
@@ -297,7 +297,7 @@
                             </xs:choice>
                             <xs:element name="vendorName" type="xp:string256Type"/>
                             <xs:element name="fundsTransferId" type="xp:string36Type" />
-                            <xs:element name="amount" type="xp:transactionAmountType" />
+                            <xs:element name="amount" type="xp:achTransactionAmountType" />
                             <xs:element name="accountInfo" type="xp:echeckTypeCtx" />
                             <xs:element name="vendorAddress" type="xp:address"  minOccurs="0"/>
                         </xs:sequence>
@@ -319,7 +319,7 @@
                             </xs:choice>
                             <xs:element name="vendorName" type="xp:string256Type"/>
                             <xs:element name="fundsTransferId" type="xp:string36Type" />
-                            <xs:element name="amount" type="xp:transactionAmountType" />
+                            <xs:element name="amount" type="xp:achTransactionAmountType" />
                             <xs:element name="accountInfo" type="xp:echeckTypeCtx" />
                             <xs:element name="vendorAddress" type="xp:address"  minOccurs="0"/>
                         </xs:sequence>
@@ -339,7 +339,7 @@
                             <xs:element name="fundingSubmerchantId" type="xp:merchantIdentificationType" />
                             <xs:element name="submerchantName" type="xp:string256Type"/>
                             <xs:element name="fundsTransferId" type="xp:string36Type" />
-                            <xs:element name="amount" type="xp:transactionAmountType" />
+                            <xs:element name="amount" type="xp:achTransactionAmountType" />
                             <xs:element name="accountInfo" type="xp:echeckTypeCtx" />
                             <xs:element name="customIdentifier" type="xp:string15Type" minOccurs="0" />
                         </xs:sequence>
@@ -358,7 +358,7 @@
                             <xs:element name="fundingSubmerchantId" type="xp:merchantIdentificationType" />
                             <xs:element name="submerchantName" type="xp:string256Type"/>
                             <xs:element name="fundsTransferId" type="xp:string36Type" />
-                            <xs:element name="amount" type="xp:transactionAmountType" />
+                            <xs:element name="amount" type="xp:achTransactionAmountType" />
                             <xs:element name="accountInfo" type="xp:echeckTypeCtx" />
                             <xs:element name="customIdentifier" type="xp:string15Type" minOccurs="0" />
                         </xs:sequence>

--- a/src/main/xsd/cnpCommon_v12.34.xsd
+++ b/src/main/xsd/cnpCommon_v12.34.xsd
@@ -298,6 +298,20 @@
             <xs:enumeration value="highRiskSecuritiesPurchase" />
             <xs:enumeration value="fundTransfer" />
             <xs:enumeration value="walletTransfer" />
+            <xs:enumeration value="accountToAccount" />
+            <xs:enumeration value="bankInitiated" />
+            <xs:enumeration value="fundsDisbursement" />
+            <xs:enumeration value="payrollDisbursement" />
+            <xs:enumeration value="personToPerson" />
+            <xs:enumeration value="topUp" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="achTransactionAmountType">
+        <xs:restriction base="xs:integer">
+            <xs:totalDigits value="10" />
+            <xs:minInclusive value="0"/>
+            <xs:maxInclusive value="9999999999"/>
         </xs:restriction>
     </xs:simpleType>
 

--- a/src/main/xsd/cnpOnline_v12.34.xsd
+++ b/src/main/xsd/cnpOnline_v12.34.xsd
@@ -3,7 +3,7 @@
 <xs:schema targetNamespace="http://www.vantivcnp.com/schema" xmlns:xp="http://www.vantivcnp.com/schema"
            xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="unqualified">
 
-    <xs:include schemaLocation="cnpTransaction_v12.33.xsd" />
+    <xs:include schemaLocation="cnpTransaction_v12.34.xsd" />
 
     <xs:complexType name="baseRequest">
         <xs:sequence>
@@ -320,7 +320,7 @@
                             </xs:choice>
                             <xs:element name="vendorName" type="xp:string256Type"/>
                             <xs:element name="fundsTransferId" type="xp:string36Type" />
-                            <xs:element name="amount" type="xp:transactionAmountType" />
+                            <xs:element name="amount" type="xp:achTransactionAmountType" />
                             <xs:element name="accountInfo" type="xp:echeckType" />
                             <xs:element name="vendorAddress" type="xp:address"  minOccurs="0"/>
                         </xs:sequence>
@@ -342,7 +342,7 @@
                             </xs:choice>
                             <xs:element name="vendorName" type="xp:string256Type"/>
                             <xs:element name="fundsTransferId" type="xp:string36Type" />
-                            <xs:element name="amount" type="xp:transactionAmountType" />
+                            <xs:element name="amount" type="xp:achTransactionAmountType" />
                             <xs:element name="accountInfo" type="xp:echeckType" />
                             <xs:element name="vendorAddress" type="xp:address"  minOccurs="0"/>
                         </xs:sequence>
@@ -362,7 +362,7 @@
                             <xs:element name="fundingSubmerchantId" type="xp:merchantIdentificationType" />
                             <xs:element name="submerchantName" type="xp:string256Type"/>
                             <xs:element name="fundsTransferId" type="xp:string36Type" />
-                            <xs:element name="amount" type="xp:transactionAmountType" />
+                            <xs:element name="amount" type="xp:achTransactionAmountType" />
                             <xs:element name="accountInfo" type="xp:echeckType" />
                             <xs:element name="customIdentifier" type="xp:string15Type" minOccurs="0" />
                         </xs:sequence>
@@ -381,7 +381,7 @@
                             <xs:element name="fundingSubmerchantId" type="xp:merchantIdentificationType" />
                             <xs:element name="submerchantName" type="xp:string256Type"/>
                             <xs:element name="fundsTransferId" type="xp:string36Type" />
-                            <xs:element name="amount" type="xp:transactionAmountType" />
+                            <xs:element name="amount" type="xp:achTransactionAmountType" />
                             <xs:element name="accountInfo" type="xp:echeckType" />
                             <xs:element name="customIdentifier" type="xp:string15Type" minOccurs="0" />
                         </xs:sequence>
@@ -428,5 +428,36 @@
             </xs:complexContent>
         </xs:complexType>
     </xs:element>-->
+    <xs:element name="finicityUrlRequest" substitutionGroup="xp:transaction">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:all>
+                        <xs:element name="firstName" type="xp:string30Type"  minOccurs="0"  />
+                        <xs:element name="lastName" type="xp:string30Type"  minOccurs="0"  />
+                        <xs:element name="phoneNumber" type="xp:phoneType"  minOccurs="0"  />
+                        <xs:element name="email" type="xp:emailType"  minOccurs="0" />
+                    </xs:all>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="finicityUrlResponse" substitutionGroup="xp:transactionResponse">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="xp:transactionTypeWithReportGroup">
+                    <xs:all>
+                        <xs:element name="cnpTxnId" type="xp:cnpIdType" minOccurs="0"/>
+                        <xs:element name="response" type="xp:responseType" minOccurs="0"/>
+                        <xs:element name="responseTime" type="xs:dateTime" minOccurs="0"/>
+                        <xs:element name="message" type="xp:messageType" minOccurs="0"/>
+                        <xs:element name="location" type="xs:string" minOccurs="0"/>
+                        <xs:element name="echeckCustomerId" type="xp:string25Type" minOccurs="0"/>
+                        <xs:element name="url" type="xs:string" minOccurs="0"/>
+                    </xs:all>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
 
 </xs:schema>

--- a/src/main/xsd/cnpOnline_v12.34.xsd
+++ b/src/main/xsd/cnpOnline_v12.34.xsd
@@ -225,7 +225,7 @@
             <xs:complexContent>
                 <xs:extension base="xp:transactionTypeWithReportGroup">
                     <xs:sequence>
-                        <xs:element name="origId" type="xp:string25Type" minOccurs="0" />
+                        <xs:element name="origId" type="xp:stringMin1Max36CollapseWhiteSpaceType" minOccurs="0" />
                         <xs:element name="origActionType" type="xp:actionTypeEnum" minOccurs="0" />
                         <xs:element name="origCnpTxnId" type="xp:cnpIdType" minOccurs="0" />
                         <xs:element name="showStatusOnly" type="xp:yesNoType" minOccurs="0" />

--- a/src/main/xsd/cnpRecurring_v12.34.xsd
+++ b/src/main/xsd/cnpRecurring_v12.34.xsd
@@ -1,7 +1,7 @@
 <xs:schema targetNamespace="http://www.vantivcnp.com/schema" xmlns:xp="http://www.vantivcnp.com/schema"
            xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="unqualified">
 
-    <xs:include schemaLocation="cnpCommon_v12.33.xsd" />
+    <xs:include schemaLocation="cnpCommon_v12.34.xsd" />
 
     <xs:element name="recurringTransaction" type="xp:recurringTransactionType" abstract="true" />
     <xs:element name="recurringTransactionResponse" type="xp:recurringTransactionResponseType" abstract="true" />

--- a/src/main/xsd/cnpTransaction_v12.34.xsd
+++ b/src/main/xsd/cnpTransaction_v12.34.xsd
@@ -2,8 +2,8 @@
            xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified"
            attributeFormDefault="unqualified">
 
-    <xs:include schemaLocation="cnpCommon_v12.33.xsd"/>
-    <xs:include schemaLocation="cnpRecurring_v12.33.xsd"/>
+    <xs:include schemaLocation="cnpCommon_v12.34.xsd"/>
+    <xs:include schemaLocation="cnpRecurring_v12.34.xsd"/>
 
     <xs:element name="transaction" type="xp:transactionType" abstract="true"/>
 
@@ -1840,6 +1840,7 @@
             <xs:element name="routingNum" type="xp:routingNumberType"/>
             <xs:element name="checkNum" type="xp:checkNumberType" minOccurs="0"/>
             <xs:element name="ccdPaymentInformation" type="xp:string80Type" minOccurs="0"/>
+            <xs:element name="echeckCustomerId" type="xp:string25Type" minOccurs="0"/>
         </xs:all>
     </xs:complexType>
 
@@ -2484,7 +2485,7 @@
                         <xs:sequence>
                             <xs:element name="fundingSubmerchantId" type="xp:merchantIdentificationType"/>
                             <xs:element name="fundsTransferId" type="xp:string36Type"/>
-                            <xs:element name="amount" type="xp:transactionAmountType"/>
+                            <xs:element name="amount" type="xp:achTransactionAmountType"/>
                         </xs:sequence>
                     </xs:choice>
                 </xs:extension>
@@ -2500,7 +2501,7 @@
                         <xs:sequence>
                             <xs:element name="fundingSubmerchantId" type="xp:merchantIdentificationType"/>
                             <xs:element name="fundsTransferId" type="xp:string36Type"/>
-                            <xs:element name="amount" type="xp:transactionAmountType"/>
+                            <xs:element name="amount" type="xp:achTransactionAmountType"/>
                         </xs:sequence>
                     </xs:choice>
                 </xs:extension>
@@ -2559,7 +2560,7 @@
                                 <xs:element name="fundingSubmerchantId" type="xp:merchantIdentificationType"/>
                             </xs:choice>
                             <xs:element name="fundsTransferId" type="xp:string36Type"/>
-                            <xs:element name="amount" type="xp:transactionAmountType"/>
+                            <xs:element name="amount" type="xp:achTransactionAmountType"/>
                         </xs:sequence>
                     </xs:choice>
                 </xs:extension>
@@ -2578,7 +2579,7 @@
                                 <xs:element name="fundingSubmerchantId" type="xp:merchantIdentificationType"/>
                             </xs:choice>
                             <xs:element name="fundsTransferId" type="xp:string36Type"/>
-                            <xs:element name="amount" type="xp:transactionAmountType"/>
+                            <xs:element name="amount" type="xp:achTransactionAmountType"/>
                         </xs:sequence>
                     </xs:choice>
                 </xs:extension>


### PR DESCRIPTION
==Version 12.34.0 (v12.34)(Feb 15, 2024)
* Change: [cnpAPI v12.34] For existing simple element 'amount' simple type is changed from 'transactionAmountType' to 'achTransactionAmountType' in below transactions vendorCredit,vendorDebit,submerchantCredit,submerchantDebit,payFacDebit,payFacCredit,reserveCredit,reserveDebit
* Change: [cnpAPI v12.34] Added new simple type 'achTransactionAmountType' to support 'amount'.
* Change: [cnpAPI v12.34] Added 'bankInitiated','fundsDisbursement','payrollDisbursement','personToPerson','topUp' in existing enum businessIndicatorEnum.
* Change: [cnpAPI v12.34] For existing element 'origId' from 'queryTransaction' simpletype changed from 'string25Type' to 'stringMin1Max36CollapseWhiteSpaceType'.
* Change: [cnpAPI v12.34] New request element 'finicityUrlRequest' is added with subfeilds-'firstName','lastName','phoneNumber','email'. 
* Change: [cnpAPI v12.34] New response element 'finicityUrlResponse' is added with              subfeilds-'cnpTxnId','response','responseTime','message','location','echeckCustomerId','url'.
* Change: [cnpAPI v12.34] New simple element 'echeckCustomerId' is added existing complex type 'echeckType'.