### PR TITLE
JavaUpgrade_V8

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 = Vantiv eCommerce CNP CHANGELOG
 
+==Version 12.34.2 (v12.34.2)(Jun 20, 2024)
+* Change: cnp-sdk-for-java is upgraded to work with Java 8 compatibility.
+
 ==Version 12.34.1 (v12.34.1)(May 6, 2024)
 * Change: cnp-sdk-for-java is upgraded to work with Java 17.
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 DIST_DIR_15=build/dist/java15
-JAR_VERSION=12.34.1
+JAR_VERSION=12.34.2
 KIT_DIR=build/kit/java15
 KIT_DEPENDENCIES_DIR=build/kit/java15/dependencies
 OPENSFTP_DIR=lib/opensftp-0.3.0

--- a/src/main/java/io/github/vantiv/sdk/Versions.java
+++ b/src/main/java/io/github/vantiv/sdk/Versions.java
@@ -3,5 +3,5 @@ package io.github.vantiv.sdk;
 public class Versions {
 
     public static final String XML_VERSION="12.34";
-    public static final String SDK_VERSION="Java;12.34.1";
+    public static final String SDK_VERSION="Java;12.34.2";
 }


### PR DESCRIPTION
==Version 12.34.2 (v12.34.2)(Jun 20, 2024)
* Change: cnp-sdk-for-java is upgraded to work with Java 8 compatibility.