### PR TITLE
Us1981750_Jakarta_upgrade 12.37.2_17

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 = Vantiv eCommerce CNP CHANGELOG
 
+==Version 12.37.2_17 (v12.37.2_17)(July 10, 2024)
+* Change: [cnpAPI v12.37.2_17] Change: cnp-sdk-for-java is upgraded to work with Jakarta v4.0.2 and Java 17 compatibility.(Replaced Javax with Jakarta)
+
 ==Version 12.37.1 (v12.37.1)(Jun 25, 2024)
 * Change: [cnpAPI v12.37.1] Change: cnp-sdk-for-java is upgraded to work with Java 8 compatibility.
 

--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ apply plugin : 'maven-publish'
 group = 'io.github.vantiv'
 version = JAR_VERSION
 
+
 repositories {
     maven  {
         url "http://repo1.maven.org/maven2"

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,6 @@ apply plugin : 'maven-publish'
 group = 'io.github.vantiv'
 version = JAR_VERSION
 
-
 repositories {
     maven  {
         url "http://repo1.maven.org/maven2"
@@ -50,19 +49,21 @@ sourceSets {
 
 dependencies{
     implementation group: 'com.jcraft', name: 'jsch', version: '0.1.55'
-    implementation group: 'com.sun.xml.bind', name: 'jaxb-core', version: '2.3.0'
-    implementation group: 'com.sun.xml.bind', name: 'jaxb-impl', version: '2.3.4'
+    implementation group: 'com.sun.xml.bind', name: 'jaxb-core', version: '4.0.5'
+    implementation group: 'com.sun.xml.bind', name: 'jaxb-impl', version: '4.0.5'
     implementation group: 'commons-io', name: 'commons-io', version: '2.11.0'
-    implementation group: 'javax.xml.bind', name: 'jaxb-api', version: '2.3.1'
+    implementation group: 'jakarta.xml.bind', name: 'jakarta.xml.bind-api', version: '4.0.2'
     implementation group: 'org.apache.httpcomponents.client5', name: 'httpclient5', version: '5.2.1'
     implementation group: 'org.bouncycastle', name: 'bcpg-jdk18on', version: '1.78.1'
     implementation group: 'org.bouncycastle', name: 'bcprov-ext-jdk15to18', version: '1.78'
+    implementation group: 'org.glassfish.jaxb', name: 'jaxb-core', version: '4.0.5'
+    generateJAXB group: 'org.glassfish.jaxb', name: 'jaxb-runtime', version: '4.0.5'
 
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'
     testImplementation group: 'org.mockito', name: 'mockito-core', version: '4.11.0'
     testImplementation 'org.slf4j:slf4j-nop:1.7.36'
 
-    generateJAXB group: 'com.sun.xml.bind', name: 'jaxb-xjc', version: '2.3.5'
+    generateJAXB group: 'org.glassfish.jaxb', name: 'jaxb-xjc', version: '4.0.5'
 }
 
 ////////// PLUGIN CONFIGURATION ////////// 
@@ -79,7 +80,7 @@ jacocoTestReport {
 
 jar{
     manifest {
-        attributes("Implementation-Title":"Cnp SDK For Java 1.5 and greater", "Implementation-Version":"${JAR_VERSION}","Implementation-Vendor":"Cnp&Co","Main-Class":"io.github.vantiv.sdk.Setup")
+        attributes("Implementation-Title":"Cnp SDK For Java 17 and greater", "Implementation-Version":"${JAR_VERSION}","Implementation-Vendor":"Cnp&Co","Main-Class":"io.github.vantiv.sdk.Setup")
     }
     getDestinationDirectory().set(file("${DIST_DIR_15}/lib"))
     getArchiveFileName().set("cnp-sdk-for-java-${JAR_VERSION}.jar")

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 DIST_DIR_15=build/dist/java15
-JAR_VERSION=12.37.1
+JAR_VERSION=12.37.2_17
 KIT_DIR=build/kit/java15
 KIT_DEPENDENCIES_DIR=build/kit/java15/dependencies
 OPENSFTP_DIR=lib/opensftp-0.3.0

--- a/src/functionalTest/java/io/github/vantiv/sdk/TestAuth.java
+++ b/src/functionalTest/java/io/github/vantiv/sdk/TestAuth.java
@@ -231,7 +231,7 @@ public class TestAuth {
         authorization.setApplepay(applepayType);
 
         AuthorizationResponse response = cnp.authorize(authorization);
-        assertEquals(new Long(110),response.getApplepayResponse().getTransactionAmount());
+        assertEquals(Long.valueOf(110),response.getApplepayResponse().getTransactionAmount());
 		assertEquals("sandbox", response.getLocation());
     }
 
@@ -698,8 +698,8 @@ public class TestAuth {
 		passengerTransportData.setCreditReasonIndicator(CreditReasonIndicatorEnum.C);
 		passengerTransportData.setTicketChangeIndicator(TicketChangeIndicatorEnum.C);
 		passengerTransportData.setTicketIssuerAddress("IssuerAddress");
-		passengerTransportData.setExchangeAmount(new Long(110));
-		passengerTransportData.setExchangeFeeAmount(new Long(112));
+		passengerTransportData.setExchangeAmount(Long.valueOf(110));
+		passengerTransportData.setExchangeFeeAmount(Long.valueOf(112));
 		passengerTransportData.setExchangeTicketNumber("ExchangeNumber");
 		passengerTransportData.getTripLegDatas().add(addTripLegData());
 		return  passengerTransportData;

--- a/src/functionalTest/java/io/github/vantiv/sdk/TestBatchFile.java
+++ b/src/functionalTest/java/io/github/vantiv/sdk/TestBatchFile.java
@@ -15,7 +15,7 @@ import java.util.GregorianCalendar;
 import java.util.List;
 import java.util.Properties;
 
-import javax.xml.bind.JAXBException;
+import jakarta.xml.bind.JAXBException;
 import javax.xml.datatype.DatatypeConfigurationException;
 import javax.xml.datatype.DatatypeFactory;
 import javax.xml.datatype.XMLGregorianCalendar;
@@ -181,7 +181,7 @@ public class TestBatchFile {
     public void testSendToCnp_WithConfigOverrides() throws Exception {
 
         Assume.assumeFalse(preliveStatus.equalsIgnoreCase("down"));
-        
+
         String workingDir = System.getProperty("java.io.tmpdir");
 
         String workingDirRequests = workingDir + File.separator
@@ -226,7 +226,7 @@ public class TestBatchFile {
             throws Exception {
 
         Assume.assumeFalse(preliveStatus.equalsIgnoreCase("down"));
-        
+
         String requestFileName = "cnpSdk-testBatchFile-fileConfigSFTP-" + TIME_STAMP + ".xml";
         CnpBatchFileRequest request = new CnpBatchFileRequest(
                 requestFileName);
@@ -277,7 +277,7 @@ public class TestBatchFile {
             throws Exception {
 
         Assume.assumeFalse(preliveStatus.equalsIgnoreCase("down"));
-        
+
         // --- Prepare the batch file ---
         String requestFileName = "cnpSdk-testBatchFile-fileConfigSFTP-" + TIME_STAMP + ".xml";
         CnpBatchFileRequest request1 = new CnpBatchFileRequest(
@@ -342,7 +342,7 @@ public class TestBatchFile {
     public void testSendToCnpSFTP_WithFileConfig() throws Exception {
 
         Assume.assumeFalse(preliveStatus.equalsIgnoreCase("down"));
-        
+
         String requestFileName = "cnpSdk-testBatchFile-fileConfigSFTP-" + TIME_STAMP + ".xml";
         CnpBatchFileRequest request = new CnpBatchFileRequest(
                 requestFileName);
@@ -382,7 +382,7 @@ public class TestBatchFile {
     public void testSendToCnpSFTP_WithConfigOverrides() throws Exception {
 
        Assume.assumeFalse(preliveStatus.equalsIgnoreCase("down"));
-        
+
         String workingDir = System.getProperty("java.io.tmpdir");
 
         String workingDirRequests = workingDir + File.separator
@@ -494,7 +494,7 @@ public class TestBatchFile {
     public void testMechaBatchAndProcess() {
 
        Assume.assumeFalse(preliveStatus.equalsIgnoreCase("down"));
-        
+
         String requestFileName = "cnpSdk-testBatchFile-MECHA-" + TIME_STAMP + ".xml";
         CnpBatchFileRequest request = new CnpBatchFileRequest(
                 requestFileName);
@@ -1214,7 +1214,7 @@ public class TestBatchFile {
     public void testEcheckPreNoteAll() {
 
         Assume.assumeFalse(preliveStatus.equalsIgnoreCase("down"));
-        
+
         String requestFileName = "cnpSdk-testBatchFile-EcheckPreNoteAll-" + TIME_STAMP + ".xml";
         CnpBatchFileRequest request = new CnpBatchFileRequest(
                 requestFileName);
@@ -1525,7 +1525,7 @@ public class TestBatchFile {
     public void testGiftCardTransactions() throws DatatypeConfigurationException {
 
        Assume.assumeFalse(preliveStatus.equalsIgnoreCase("down"));
-        
+
         String requestFileName = "cnpSdk-testBatchFile-GiftCardTransactions-" + TIME_STAMP + ".xml";
         CnpBatchFileRequest request = new CnpBatchFileRequest(
                 requestFileName);
@@ -1929,7 +1929,7 @@ public class TestBatchFile {
     public void testMechaBatchAndProcess_RecurringDemonstratesUseOfProcessorAdapter() {
 
         Assume.assumeFalse(preliveStatus.equalsIgnoreCase("down"));
-        
+
         String requestFileName = "cnpSdk-testBatchFile-RECURRING-" + TIME_STAMP + ".xml";
         CnpBatchFileRequest request = new CnpBatchFileRequest(
                 requestFileName);
@@ -2006,7 +2006,7 @@ public class TestBatchFile {
     public void testBatch_AU() {
 
         Assume.assumeFalse(preliveStatus.equalsIgnoreCase("down"));
-        
+
         String requestFileName = "cnpSdk-testBatchFile_AU-" + TIME_STAMP + ".xml";
         CnpBatchFileRequest request = new CnpBatchFileRequest(
                 requestFileName);

--- a/src/functionalTest/java/io/github/vantiv/sdk/TestCapture.java
+++ b/src/functionalTest/java/io/github/vantiv/sdk/TestCapture.java
@@ -123,8 +123,8 @@ public class TestCapture {
 		passengerTransportData.setCreditReasonIndicator(CreditReasonIndicatorEnum.C);
 		passengerTransportData.setTicketChangeIndicator(TicketChangeIndicatorEnum.C);
 		passengerTransportData.setTicketIssuerAddress("IssuerAddress");
-		passengerTransportData.setExchangeAmount(new Long(110));
-		passengerTransportData.setExchangeFeeAmount(new Long(112));
+		passengerTransportData.setExchangeAmount(Long.valueOf(110));
+		passengerTransportData.setExchangeFeeAmount(Long.valueOf(112));
 		passengerTransportData.setExchangeTicketNumber("ExchangeNumber");
 		passengerTransportData.getTripLegDatas().add(addTripLegData());
 		return  passengerTransportData;

--- a/src/functionalTest/java/io/github/vantiv/sdk/TestCaptureGivenAuth.java
+++ b/src/functionalTest/java/io/github/vantiv/sdk/TestCaptureGivenAuth.java
@@ -428,8 +428,8 @@ public class TestCaptureGivenAuth {
 		passengerTransportData.setCreditReasonIndicator(CreditReasonIndicatorEnum.C);
 		passengerTransportData.setTicketChangeIndicator(TicketChangeIndicatorEnum.C);
 		passengerTransportData.setTicketIssuerAddress("IssuerAddress");
-		passengerTransportData.setExchangeAmount(new Long(110));
-		passengerTransportData.setExchangeFeeAmount(new Long(112));
+		passengerTransportData.setExchangeAmount(Long.valueOf(110));
+		passengerTransportData.setExchangeFeeAmount(Long.valueOf(112));
 		passengerTransportData.setExchangeTicketNumber("ExchangeNumber");
 		passengerTransportData.getTripLegDatas().add(addTripLegData());
 		return  passengerTransportData;

--- a/src/functionalTest/java/io/github/vantiv/sdk/TestCredit.java
+++ b/src/functionalTest/java/io/github/vantiv/sdk/TestCredit.java
@@ -268,8 +268,8 @@ public class TestCredit {
         passengerTransportData.setCreditReasonIndicator(CreditReasonIndicatorEnum.C);
         passengerTransportData.setTicketChangeIndicator(TicketChangeIndicatorEnum.C);
         passengerTransportData.setTicketIssuerAddress("IssuerAddress");
-        passengerTransportData.setExchangeAmount(new Long(110));
-        passengerTransportData.setExchangeFeeAmount(new Long(112));
+        passengerTransportData.setExchangeAmount(Long.valueOf(110));
+        passengerTransportData.setExchangeFeeAmount(Long.valueOf(112));
         passengerTransportData.setExchangeTicketNumber("ExchangeNumber");
         passengerTransportData.getTripLegDatas().add(addTripLegData());
         return  passengerTransportData;

--- a/src/functionalTest/java/io/github/vantiv/sdk/TestDepositTransactionReversal.java
+++ b/src/functionalTest/java/io/github/vantiv/sdk/TestDepositTransactionReversal.java
@@ -96,8 +96,8 @@ public class TestDepositTransactionReversal {
         passengerTransportData.setCreditReasonIndicator(CreditReasonIndicatorEnum.C);
         passengerTransportData.setTicketChangeIndicator(TicketChangeIndicatorEnum.C);
         passengerTransportData.setTicketIssuerAddress("IssuerAddress");
-        passengerTransportData.setExchangeAmount(new Long(110));
-        passengerTransportData.setExchangeFeeAmount(new Long(112));
+        passengerTransportData.setExchangeAmount(Long.valueOf(110));
+        passengerTransportData.setExchangeFeeAmount(Long.valueOf(112));
         passengerTransportData.setExchangeTicketNumber("ExchangeNumber");
         passengerTransportData.getTripLegDatas().add(addTripLegData());
         return  passengerTransportData;

--- a/src/functionalTest/java/io/github/vantiv/sdk/TestForceCapture.java
+++ b/src/functionalTest/java/io/github/vantiv/sdk/TestForceCapture.java
@@ -143,8 +143,8 @@ public class TestForceCapture {
 		passengerTransportData.setCreditReasonIndicator(CreditReasonIndicatorEnum.C);
 		passengerTransportData.setTicketChangeIndicator(TicketChangeIndicatorEnum.C);
 		passengerTransportData.setTicketIssuerAddress("IssuerAddress");
-		passengerTransportData.setExchangeAmount(new Long(110));
-		passengerTransportData.setExchangeFeeAmount(new Long(112));
+		passengerTransportData.setExchangeAmount(Long.valueOf(110));
+		passengerTransportData.setExchangeFeeAmount(Long.valueOf(112));
 		passengerTransportData.setExchangeTicketNumber("ExchangeNumber");
 		passengerTransportData.getTripLegDatas().add(addTripLegData());
 		return  passengerTransportData;

--- a/src/functionalTest/java/io/github/vantiv/sdk/TestFraudCheck.java
+++ b/src/functionalTest/java/io/github/vantiv/sdk/TestFraudCheck.java
@@ -46,7 +46,7 @@ public class TestFraudCheck {
         
         AdvancedFraudResultsType advancedFraudResultsType = fraudCheckResponse.getAdvancedFraudResults();
         assertEquals("pass", advancedFraudResultsType.getDeviceReviewStatus());
-        assertEquals(new Integer(42), advancedFraudResultsType.getDeviceReputationScore());
+        assertEquals(Integer.valueOf(42), advancedFraudResultsType.getDeviceReputationScore());
         assertEquals(5, advancedFraudResultsType.getTriggeredRules().size());
     }
 }

--- a/src/functionalTest/java/io/github/vantiv/sdk/TestRefundTransactionReversal.java
+++ b/src/functionalTest/java/io/github/vantiv/sdk/TestRefundTransactionReversal.java
@@ -96,8 +96,8 @@ public class TestRefundTransactionReversal {
         passengerTransportData.setCreditReasonIndicator(CreditReasonIndicatorEnum.C);
         passengerTransportData.setTicketChangeIndicator(TicketChangeIndicatorEnum.C);
         passengerTransportData.setTicketIssuerAddress("IssuerAddress");
-        passengerTransportData.setExchangeAmount(new Long(110));
-        passengerTransportData.setExchangeFeeAmount(new Long(112));
+        passengerTransportData.setExchangeAmount(Long.valueOf(110));
+        passengerTransportData.setExchangeFeeAmount(Long.valueOf(112));
         passengerTransportData.setExchangeTicketNumber("ExchangeNumber");
         passengerTransportData.getTripLegDatas().add(addTripLegData());
         return  passengerTransportData;

--- a/src/functionalTest/java/io/github/vantiv/sdk/TestSale.java
+++ b/src/functionalTest/java/io/github/vantiv/sdk/TestSale.java
@@ -133,7 +133,7 @@ public class TestSale {
         sale.setId("id");
         SaleResponse response = cnp.sale(sale);
         assertEquals("Insufficient Funds", response.getMessage());
-        assertEquals(new Long(110),response.getApplepayResponse().getTransactionAmount());
+        assertEquals(Long.valueOf(110),response.getApplepayResponse().getTransactionAmount());
 		assertEquals("sandbox", response.getLocation());
     }
 	
@@ -572,8 +572,8 @@ public class TestSale {
 		passengerTransportData.setCreditReasonIndicator(CreditReasonIndicatorEnum.C);
 		passengerTransportData.setTicketChangeIndicator(TicketChangeIndicatorEnum.C);
 		passengerTransportData.setTicketIssuerAddress("IssuerAddress");
-		passengerTransportData.setExchangeAmount(new Long(110));
-		passengerTransportData.setExchangeFeeAmount(new Long(112));
+		passengerTransportData.setExchangeAmount(Long.valueOf(110));
+		passengerTransportData.setExchangeFeeAmount(Long.valueOf(112));
 		passengerTransportData.setExchangeTicketNumber("ExchangeNumber");
 		passengerTransportData.getTripLegDatas().add(addTripLegData());
 		return  passengerTransportData;

--- a/src/functionalTest/java/io/github/vantiv/sdk/TestToken.java
+++ b/src/functionalTest/java/io/github/vantiv/sdk/TestToken.java
@@ -91,7 +91,7 @@ public class TestToken {
         token.setId("id");
         RegisterTokenResponse response = cnp.registerToken(token);
         assertEquals("Account number was successfully registered", response.getMessage());
-        assertEquals(new Long(0),response.getApplepayResponse().getTransactionAmount());
+        assertEquals(Long.valueOf(0),response.getApplepayResponse().getTransactionAmount());
 		assertEquals("sandbox", response.getLocation());
     }
 	

--- a/src/main/java/io/github/vantiv/sdk/CnpBatchFileRequest.java
+++ b/src/main/java/io/github/vantiv/sdk/CnpBatchFileRequest.java
@@ -6,9 +6,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
 
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Marshaller;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Marshaller;
 
 import io.github.vantiv.sdk.generate.Authentication;
 import io.github.vantiv.sdk.generate.CnpRequest;

--- a/src/main/java/io/github/vantiv/sdk/CnpBatchFileResponse.java
+++ b/src/main/java/io/github/vantiv/sdk/CnpBatchFileResponse.java
@@ -2,7 +2,7 @@ package io.github.vantiv.sdk;
 
 import java.io.File;
 
-import javax.xml.bind.JAXBException;
+import jakarta.xml.bind.JAXBException;
 
 
 public class CnpBatchFileResponse extends CnpFileResponse{

--- a/src/main/java/io/github/vantiv/sdk/CnpBatchRequest.java
+++ b/src/main/java/io/github/vantiv/sdk/CnpBatchRequest.java
@@ -7,10 +7,10 @@ import java.sql.Timestamp;
 import java.text.SimpleDateFormat;
 import java.util.Properties;
 
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBElement;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Marshaller;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBElement;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Marshaller;
 
 import io.github.vantiv.sdk.generate.*;
 import org.bouncycastle.openpgp.PGPException;

--- a/src/main/java/io/github/vantiv/sdk/CnpBatchResponse.java
+++ b/src/main/java/io/github/vantiv/sdk/CnpBatchResponse.java
@@ -4,10 +4,10 @@ import java.io.StringReader;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBElement;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Unmarshaller;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBElement;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Unmarshaller;
 
 import io.github.vantiv.sdk.generate.BatchResponse;
 import io.github.vantiv.sdk.generate.CnpTransactionInterface;

--- a/src/main/java/io/github/vantiv/sdk/CnpContext.java
+++ b/src/main/java/io/github/vantiv/sdk/CnpContext.java
@@ -1,7 +1,7 @@
 package io.github.vantiv.sdk;
 
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
 
 import io.github.vantiv.sdk.generate.ObjectFactory;
 

--- a/src/main/java/io/github/vantiv/sdk/CnpFileResponse.java
+++ b/src/main/java/io/github/vantiv/sdk/CnpFileResponse.java
@@ -4,9 +4,9 @@ import java.io.File;
 import java.io.IOException;
 import java.io.StringReader;
 
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Unmarshaller;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Unmarshaller;
 
 import io.github.vantiv.sdk.generate.CnpResponse;
 

--- a/src/main/java/io/github/vantiv/sdk/CnpOnline.java
+++ b/src/main/java/io/github/vantiv/sdk/CnpOnline.java
@@ -7,8 +7,8 @@ import java.io.StringReader;
 import java.io.StringWriter;
 import java.util.Properties;
 
-import javax.xml.bind.JAXBElement;
-import javax.xml.bind.JAXBException;
+import jakarta.xml.bind.JAXBElement;
+import jakarta.xml.bind.JAXBException;
 
 import io.github.vantiv.sdk.generate.*;
 import io.github.vantiv.sdk.generate.Void;

--- a/src/main/java/io/github/vantiv/sdk/CnpRFRFileRequest.java
+++ b/src/main/java/io/github/vantiv/sdk/CnpRFRFileRequest.java
@@ -10,9 +10,9 @@ import java.io.StringWriter;
 import java.math.BigInteger;
 import java.util.Properties;
 
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Marshaller;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Marshaller;
 
 import io.github.vantiv.sdk.generate.Authentication;
 import io.github.vantiv.sdk.generate.CnpRequest;

--- a/src/main/java/io/github/vantiv/sdk/CnpRFRFileResponse.java
+++ b/src/main/java/io/github/vantiv/sdk/CnpRFRFileResponse.java
@@ -2,7 +2,7 @@ package io.github.vantiv.sdk;
 
 import java.io.File;
 
-import javax.xml.bind.JAXBException;
+import jakarta.xml.bind.JAXBException;
 
 /**
  * Container class holding the RFR response

--- a/src/main/java/io/github/vantiv/sdk/CnpRFRResponse.java
+++ b/src/main/java/io/github/vantiv/sdk/CnpRFRResponse.java
@@ -2,9 +2,9 @@ package io.github.vantiv.sdk;
 
 import java.io.StringReader;
 
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Unmarshaller;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Unmarshaller;
 
 import io.github.vantiv.sdk.generate.RFRResponse;
 

--- a/src/main/java/io/github/vantiv/sdk/JAXBConverters.java
+++ b/src/main/java/io/github/vantiv/sdk/JAXBConverters.java
@@ -8,7 +8,7 @@ public class JAXBConverters {
         if(value == null){
             return null;
         }
-        return (javax.xml.bind.DatatypeConverter.parseDate(value));
+        return (jakarta.xml.bind.DatatypeConverter.parseDate(value));
     }
 
     public static String printDate(Calendar value){

--- a/src/main/java/io/github/vantiv/sdk/Versions.java
+++ b/src/main/java/io/github/vantiv/sdk/Versions.java
@@ -3,5 +3,5 @@ package io.github.vantiv.sdk;
 public class Versions {
 
     public static final String XML_VERSION="12.37";
-    public static final String SDK_VERSION="Java;12.37.1";
+    public static final String SDK_VERSION="Java;12.37.2_17";
 }

--- a/src/test/java/io/github/vantiv/sdk/TestCnpBatchFileRequest.java
+++ b/src/test/java/io/github/vantiv/sdk/TestCnpBatchFileRequest.java
@@ -7,8 +7,8 @@ import static org.junit.Assert.assertTrue;
 import java.io.FileNotFoundException;
 import java.util.Properties;
 
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Marshaller;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Marshaller;
 
 import org.junit.Before;
 import org.junit.Test;

--- a/src/test/java/io/github/vantiv/sdk/TestCnpBatchRequest.java
+++ b/src/test/java/io/github/vantiv/sdk/TestCnpBatchRequest.java
@@ -7,8 +7,8 @@ import java.io.FileNotFoundException;
 import java.math.BigInteger;
 import java.util.Properties;
 
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Marshaller;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Marshaller;
 
 import io.github.vantiv.sdk.generate.*;
 import org.junit.Before;

--- a/src/test/java/io/github/vantiv/sdk/TestCnpContext.java
+++ b/src/test/java/io/github/vantiv/sdk/TestCnpContext.java
@@ -2,7 +2,7 @@ package io.github.vantiv.sdk;
 
 import static org.junit.Assert.assertSame;
 
-import javax.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBContext;
 
 import io.github.vantiv.sdk.generate.ObjectFactory;
 import org.junit.Test;

--- a/src/test/java/io/github/vantiv/sdk/TestCnpOnline.java
+++ b/src/test/java/io/github/vantiv/sdk/TestCnpOnline.java
@@ -4,7 +4,7 @@ import io.github.vantiv.sdk.generate.*;
 import org.junit.Before;
 import org.junit.Test;
 
-import javax.xml.bind.JAXBElement;
+import jakarta.xml.bind.JAXBElement;
 import javax.xml.datatype.DatatypeFactory;
 import javax.xml.datatype.XMLGregorianCalendar;
 
@@ -95,7 +95,7 @@ public class TestCnpOnline {
         AuthorizationResponse authorize = cnp.authorize(authorization);
         assertEquals(123L, authorize.getCnpTxnId());
         assertEquals("123455", authorize.getApplepayResponse().getApplicationPrimaryAccountNumber());
-        assertEquals(new Long(106), authorize.getApplepayResponse().getTransactionAmount());
+        assertEquals(Long.valueOf(106), authorize.getApplepayResponse().getTransactionAmount());
 		assertEquals("sandbox", authorize.getLocation());
     }
 
@@ -2457,7 +2457,7 @@ public class TestCnpOnline {
         FraudCheckResponse fraudCheckResponse = cnp.fraudCheck(fraudCheck);
         AdvancedFraudResultsType advancedFraudResultsType = fraudCheckResponse.getAdvancedFraudResults();
         assertEquals("pass", advancedFraudResultsType.getDeviceReviewStatus());
-        assertEquals(new Integer(42), advancedFraudResultsType.getDeviceReputationScore());
+        assertEquals(Integer.valueOf(42), advancedFraudResultsType.getDeviceReputationScore());
         assertEquals(5, advancedFraudResultsType.getTriggeredRules().size());
 		assertEquals("sandbox", fraudCheckResponse.getLocation());
     }

--- a/src/test/java/io/github/vantiv/sdk/TestEnumerations.java
+++ b/src/test/java/io/github/vantiv/sdk/TestEnumerations.java
@@ -4,8 +4,8 @@ import static org.junit.Assert.*;
 
 import java.io.StringWriter;
 
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.Marshaller;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.Marshaller;
 
 import io.github.vantiv.sdk.generate.*;
 import org.junit.Test;


### PR DESCRIPTION
==Version 12.37.2_17 (v12.37.2_17)(July 10, 2024)
* Change: [cnpAPI v12.37.2_17] Change: cnp-sdk-for-java is upgraded to work with Jakarta v4.0.2 and Java 17 compatibility.(Replaced Javax with Jakarta)