### PR TITLE
Committing JaxB-Core related changes.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 = Vantiv eCommerce CNP CHANGELOG
 
+==Version 12.37.4_17 (v12.37.4_17)(July 29, 2024)
+* Change: [cnpAPI v12.37.4_17] Change: Removed Glassfish Package-Jaxb-Core duplicate dependency which supports Jakarta namespace.
+
 ==Version 12.37.3_17 (v12.37.3_17)(July 23, 2024)
 * Change: [cnpAPI v12.37.3_17] Change: Removed Jaxb-Core duplicate dependency which supports Jakarta namespace.
 

--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,6 @@ dependencies{
     implementation group: 'org.apache.httpcomponents.client5', name: 'httpclient5', version: '5.2.1'
     implementation group: 'org.bouncycastle', name: 'bcpg-jdk18on', version: '1.78.1'
     implementation group: 'org.bouncycastle', name: 'bcprov-ext-jdk15to18', version: '1.78'
-    implementation group: 'org.glassfish.jaxb', name: 'jaxb-core', version: '4.0.5'
     generateJAXB group: 'org.glassfish.jaxb', name: 'jaxb-runtime', version: '4.0.5'
 
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 DIST_DIR_15=build/dist/java15
-JAR_VERSION=12.37.3_17
+JAR_VERSION=12.37.4_17
 KIT_DIR=build/kit/java15
 KIT_DEPENDENCIES_DIR=build/kit/java15/dependencies
 OPENSFTP_DIR=lib/opensftp-0.3.0

--- a/src/main/java/io/github/vantiv/sdk/Versions.java
+++ b/src/main/java/io/github/vantiv/sdk/Versions.java
@@ -3,5 +3,5 @@ package io.github.vantiv.sdk;
 public class Versions {
 
     public static final String XML_VERSION="12.37";
-    public static final String SDK_VERSION="Java;12.37.3_17";
+    public static final String SDK_VERSION="Java;12.37.4_17";
 }


### PR DESCRIPTION
==Version 12.37.4_17 (v12.37.4_17)(July 29, 2024)
* Change: [cnpAPI v12.37.4_17] Change: Removed Glassfish Package-Jaxb-Core duplicate dependency which supports Jakarta namespace.