### PR TITLE
cnp-sdk-for-java-V12.45

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,10 @@
 = Vantiv eCommerce CNP CHANGELOG
 
+==Change Log for 12.45 (May 22,2025)
+* Change: [cnpAPI v12.45] In existing enum 'foreignRetailerIndicatorEnum' new values 'A','B'.
+* Change: [cnpAPI v12.45] In existing authorization request new element 'foreignRetailerIndicator' of type 'foreignRetailerIndicatorEnum' is added.
+* Change: [cnpAPI v12.45] In existing requests 'authorization','sale','captureGivenAuth' type of existing element 'typeOfDigitalCurrency' is changed from string to 'typeOfDigitalCurrencyEnum'.
+
 ==Change Log for 12.44.1 (March 06,2025)
 * Change: Upgraded commons-io 2.11.0 to commons-io 2.18.0 to fix BD vulnerability.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,8 +3,7 @@
 ==Change Log for 12.45 (May 22,2025)
 * Change: [cnpAPI v12.45] In existing enum 'foreignRetailerIndicatorEnum' new values 'A','B'.
 * Change: [cnpAPI v12.45] In existing authorization request new element 'foreignRetailerIndicator' of type 'foreignRetailerIndicatorEnum' is added in orderId sequence.
-* Change: [cnpAPI v12.45] New enum 'typeOfDigitalCurrencyEnum' is added with the values '1','2','3','4','5','6','7'.
-* Change: [cnpAPI v12.45] In existing requests 'authorization','sale','captureGivenAuth' type of existing element 'typeOfDigitalCurrency' is changed from string to 'typeOfDigitalCurrencyEnum'.
+* Change: [cnpAPI v12.45] In existing element 'typeOfDigitalCurrency' is modified to support only these value '1','2','3','4','7'.
 
 ==Change Log for 12.44.1 (March 06,2025)
 * Change: Upgraded commons-io 2.11.0 to commons-io 2.18.0 to fix BD vulnerability.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,7 +2,8 @@
 
 ==Change Log for 12.45 (May 22,2025)
 * Change: [cnpAPI v12.45] In existing enum 'foreignRetailerIndicatorEnum' new values 'A','B'.
-* Change: [cnpAPI v12.45] In existing authorization request new element 'foreignRetailerIndicator' of type 'foreignRetailerIndicatorEnum' is added.
+* Change: [cnpAPI v12.45] In existing authorization request new element 'foreignRetailerIndicator' of type 'foreignRetailerIndicatorEnum' is added in orderId sequence.
+* Change: [cnpAPI v12.45] New enum 'typeOfDigitalCurrencyEnum' is added with the values '1','2','3','4','5','6','7'.
 * Change: [cnpAPI v12.45] In existing requests 'authorization','sale','captureGivenAuth' type of existing element 'typeOfDigitalCurrency' is changed from string to 'typeOfDigitalCurrencyEnum'.
 
 ==Change Log for 12.44.1 (March 06,2025)

--- a/README.md
+++ b/README.md
@@ -195,7 +195,15 @@ Example for encryptionKeyRequest:
     }
 ```
 
+6.  Below is the sample to set element 'typeOfDigitalCurrency' and 'typeOfDigitalCurrencyEnum'.
+
+    authorization.setTypeOfDigitalCurrency(TypeOfDigitalCurrencyEnum.ONE.getValue());
+		
+
 There is one example shown in Note section can be used to validate transaction processing  after doing all setup . 
 
 More examples can be found here [Java Gists](https://gist.github.com/VantivSDK)
+
+
+
 

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ Example for encryptionKeyRequest:
 
 6.  Below is the sample to set element 'typeOfDigitalCurrency' and 'typeOfDigitalCurrencyEnum'.
 
-    authorization.setTypeOfDigitalCurrency(TypeOfDigitalCurrencyEnum.ONE.getValue());
+    authorization.setTypeOfDigitalCurrency("1");
 		
 
 There is one example shown in Note section can be used to validate transaction processing  after doing all setup . 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,4 +3,4 @@ JAR_VERSION=12.44.1
 KIT_DIR=build/kit/java15
 KIT_DEPENDENCIES_DIR=build/kit/java15/dependencies
 OPENSFTP_DIR=lib/opensftp-0.3.0
-SCHEMA_VERSION=12.44
+SCHEMA_VERSION=12.45

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 DIST_DIR_15=build/dist/java15
-JAR_VERSION=12.44.1
+JAR_VERSION=12.45.0
 KIT_DIR=build/kit/java15
 KIT_DEPENDENCIES_DIR=build/kit/java15/dependencies
 OPENSFTP_DIR=lib/opensftp-0.3.0

--- a/src/functionalTest/java/io/github/vantiv/sdk/TestAuth.java
+++ b/src/functionalTest/java/io/github/vantiv/sdk/TestAuth.java
@@ -1122,7 +1122,7 @@ public class TestAuth {
 		card.setNumber("4100000000000000");
 		card.setExpDate("1210");
 		authorization.setCard(card);
-		authorization.setTypeOfDigitalCurrency("2");
+		authorization.setTypeOfDigitalCurrency("7");
 		authorization.setConversionAffiliateId("ABCD");
 		AuthorizationResponse response = cnp.authorize(authorization);
 		assertEquals(response.getMessage(), "000",response.getResponse());

--- a/src/functionalTest/java/io/github/vantiv/sdk/TestAuth.java
+++ b/src/functionalTest/java/io/github/vantiv/sdk/TestAuth.java
@@ -1122,7 +1122,7 @@ public class TestAuth {
 		card.setNumber("4100000000000000");
 		card.setExpDate("1210");
 		authorization.setCard(card);
-		authorization.setTypeOfDigitalCurrency("7");
+		authorization.setTypeOfDigitalCurrency("1");
 		authorization.setConversionAffiliateId("ABCD");
 		AuthorizationResponse response = cnp.authorize(authorization);
 		assertEquals(response.getMessage(), "000",response.getResponse());

--- a/src/functionalTest/java/io/github/vantiv/sdk/TestBatchFile.java
+++ b/src/functionalTest/java/io/github/vantiv/sdk/TestBatchFile.java
@@ -541,7 +541,7 @@ public class TestBatchFile {
         auth.setOrderSource(OrderSourceType.ECOMMERCE);
         auth.setCard(card);
         auth.setCardholderAuthentication(fraudCheckType1);
-        auth.setTypeOfDigitalCurrency("2");
+        auth.setTypeOfDigitalCurrency("7");
         auth.setConversionAffiliateId("ABCD");
         auth.setId("id");
         LodgingInfo lodgingInfo = new LodgingInfo();
@@ -560,7 +560,7 @@ public class TestBatchFile {
         sale.setAmount(6000L);
         sale.setOrderSource(OrderSourceType.ECOMMERCE);
         sale.setCard(card);
-        sale.setTypeOfDigitalCurrency("2");
+        sale.setTypeOfDigitalCurrency("7");
         sale.setConversionAffiliateId("ABCD");
         sale.setId("id");
         sale.setIdentityBundle(identityBundle());

--- a/src/functionalTest/java/io/github/vantiv/sdk/TestCaptureGivenAuth.java
+++ b/src/functionalTest/java/io/github/vantiv/sdk/TestCaptureGivenAuth.java
@@ -592,7 +592,7 @@ public class TestCaptureGivenAuth {
 		card.setNumber("4100000000000000");
 		card.setExpDate("1210");
 		capturegivenauth.setCard(card);
-		capturegivenauth.setTypeOfDigitalCurrency("2");
+		capturegivenauth.setTypeOfDigitalCurrency("7");
 		capturegivenauth.setConversionAffiliateId("ABCD");
 		capturegivenauth.setId("id");
 		CaptureGivenAuthResponse response = cnp.captureGivenAuth(capturegivenauth);

--- a/src/functionalTest/java/io/github/vantiv/sdk/TestSale.java
+++ b/src/functionalTest/java/io/github/vantiv/sdk/TestSale.java
@@ -375,6 +375,7 @@ public class TestSale {
 		card.setExpDate("1215");
 		card.setType(MethodOfPaymentTypeEnum.VI);
 		sale.setCard(card);
+		sale.setForeignRetailerIndicator(ForeignRetailerIndicatorEnum.B);
 		SaleResponse response = cnp.sale(sale);
 		assertEquals(response.getMessage(), "Approved", response.getMessage());
 		assertEquals("sandbox", response.getLocation());

--- a/src/main/java/io/github/vantiv/sdk/TypeOfDigitalCurrencyEnum.java
+++ b/src/main/java/io/github/vantiv/sdk/TypeOfDigitalCurrencyEnum.java
@@ -1,0 +1,44 @@
+package io.github.vantiv.sdk;
+
+import io.github.vantiv.sdk.generate.ForeignRetailerIndicatorEnum;
+
+import javax.xml.bind.annotation.XmlEnum;
+import javax.xml.bind.annotation.XmlEnumValue;
+import javax.xml.bind.annotation.XmlType;
+
+@XmlType(name = "typeOfDigitalCurrencyEnum")
+@XmlEnum
+public enum TypeOfDigitalCurrencyEnum {
+
+    @XmlEnumValue("1")
+    ONE("1"),
+    @XmlEnumValue("2")
+    TWO("2"),
+    @XmlEnumValue("3")
+    THREE("3"),
+    @XmlEnumValue("4")
+    FOUR("4"),
+    @XmlEnumValue("7")
+    SEVEN("7");
+
+    private final String value;
+
+    TypeOfDigitalCurrencyEnum(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+
+}
+
+
+    public static TypeOfDigitalCurrencyEnum fromValue(String value) {
+        for (TypeOfDigitalCurrencyEnum enumValue : TypeOfDigitalCurrencyEnum.values()) {
+            if (enumValue.value.equals(value)) {
+                return enumValue;
+            }
+        }
+        throw new IllegalArgumentException("Invalid value: " + value);
+    }
+}

--- a/src/main/java/io/github/vantiv/sdk/Versions.java
+++ b/src/main/java/io/github/vantiv/sdk/Versions.java
@@ -2,6 +2,6 @@ package io.github.vantiv.sdk;
 
 public class Versions {
 
-    public static final String XML_VERSION="12.44";
-    public static final String SDK_VERSION="Java;12.44.1";
+    public static final String XML_VERSION = "12.45";
+    public static final String SDK_VERSION = "Java;12.45";
 }

--- a/src/main/java/io/github/vantiv/sdk/Versions.java
+++ b/src/main/java/io/github/vantiv/sdk/Versions.java
@@ -3,5 +3,5 @@ package io.github.vantiv.sdk;
 public class Versions {
 
     public static final String XML_VERSION = "12.45";
-    public static final String SDK_VERSION = "Java;12.45";
+    public static final String SDK_VERSION = "Java;12.45.0";
 }

--- a/src/main/xsd/cnpBatch_v12.45.xsd
+++ b/src/main/xsd/cnpBatch_v12.45.xsd
@@ -2,7 +2,7 @@
 <xs:schema targetNamespace="http://www.vantivcnp.com/schema" xmlns:xs="http://www.w3.org/2001/XMLSchema"
            xmlns:xp="http://www.vantivcnp.com/schema" elementFormDefault="qualified" attributeFormDefault="unqualified">
 
-    <xs:include schemaLocation="cnpTransaction_v12.44.xsd" />
+    <xs:include schemaLocation="cnpTransaction_v12.45.xsd" />
 
     <xs:element name="cnpRequest">
         <xs:complexType>

--- a/src/main/xsd/cnpCommon_v12.45.xsd
+++ b/src/main/xsd/cnpCommon_v12.45.xsd
@@ -161,7 +161,7 @@
     <xs:simpleType name="stringipAddress">
         <xs:restriction base="xs:string">
             <xs:maxLength value="100" />
-            <xs:pattern value="[A-Z,a-z,0-9, ,:,.]*"/>
+            <xs:pattern value="[A-Za-z0-9 :.]*"/>
         </xs:restriction>
     </xs:simpleType>
 
@@ -803,7 +803,7 @@
     <xs:simpleType name="customBillingUrlType">
         <xs:restriction base="xs:string">
             <xs:maxLength value="13" />
-            <xs:pattern value="[A-Z,a-z,0-9,/,\-,_,.]*"/>
+            <xs:pattern value="[A-Za-z0-9/\-_.]*"/>
         </xs:restriction>
     </xs:simpleType>
 
@@ -1077,7 +1077,7 @@
     </xs:simpleType>
     <xs:simpleType name="awpTokenUrlType">
         <xs:restriction base="xs:string">
-            <xs:pattern value="http.?://.*/.*"/>
+            <xs:pattern value="https?://[^/]+/.*"/>
             <xs:maxLength value="400"/>
         </xs:restriction>
     </xs:simpleType>
@@ -1152,7 +1152,7 @@
 
     <xs:simpleType name="stringExactly16AlphanumericType">
         <xs:restriction base="xs:string">
-            <xs:pattern value="[A-Z,a-z,0-9]{16,16}"/>
+            <xs:pattern value="[A-Za-z0-9]{16,16}"/>
         </xs:restriction>
     </xs:simpleType>
 
@@ -1396,6 +1396,9 @@
     <xs:simpleType name="foreignRetailerIndicatorEnum">
         <xs:restriction base="xs:string">
             <xs:enumeration value="F" />
+            <!--    US2081172-79564-->
+            <xs:enumeration value="A" />
+            <xs:enumeration value="B" />
         </xs:restriction>
     </xs:simpleType>
 
@@ -1428,6 +1431,17 @@
         <xs:restriction base="xs:integer">
             <xs:minInclusive value="1" />
             <xs:maxInclusive value="99" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <!--    US2081172-79564-->
+    <xs:simpleType name="typeOfDigitalCurrencyEnum">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="1" />
+            <xs:enumeration value="2" />
+            <xs:enumeration value="3" />
+            <xs:enumeration value="4" />
+            <xs:enumeration value="7" />
         </xs:restriction>
     </xs:simpleType>
 

--- a/src/main/xsd/cnpOnline_v12.45.xsd
+++ b/src/main/xsd/cnpOnline_v12.45.xsd
@@ -3,7 +3,7 @@
 <xs:schema targetNamespace="http://www.vantivcnp.com/schema" xmlns:xp="http://www.vantivcnp.com/schema"
            xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="unqualified">
 
-    <xs:include schemaLocation="cnpTransaction_v12.44.xsd" />
+    <xs:include schemaLocation="cnpTransaction_v12.45.xsd" />
 
     <xs:complexType name="baseRequest">
         <xs:sequence>
@@ -430,8 +430,8 @@
                 </xs:extension>
             </xs:complexContent>
         </xs:complexType>
-    </xs:element>
--->
+    </xs:element>-->
+
     <xs:element name="BNPLAuthorizationRequest" substitutionGroup="xp:transaction">
         <xs:complexType>
             <xs:complexContent>

--- a/src/main/xsd/cnpRecurring_v12.45.xsd
+++ b/src/main/xsd/cnpRecurring_v12.45.xsd
@@ -1,7 +1,7 @@
 <xs:schema targetNamespace="http://www.vantivcnp.com/schema" xmlns:xp="http://www.vantivcnp.com/schema"
            xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="unqualified">
 
-    <xs:include schemaLocation="cnpCommon_v12.44.xsd" />
+    <xs:include schemaLocation="cnpCommon_v12.45.xsd" />
 
     <xs:element name="recurringTransaction" type="xp:recurringTransactionType" abstract="true" />
     <xs:element name="recurringTransactionResponse" type="xp:recurringTransactionResponseType" abstract="true" />

--- a/src/main/xsd/cnpTransaction_v12.45.xsd
+++ b/src/main/xsd/cnpTransaction_v12.45.xsd
@@ -2,8 +2,8 @@
            xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified"
            attributeFormDefault="unqualified">
 
-    <xs:include schemaLocation="cnpCommon_v12.44.xsd"/>
-    <xs:include schemaLocation="cnpRecurring_v12.44.xsd"/>
+    <xs:include schemaLocation="cnpCommon_v12.45.xsd"/>
+    <xs:include schemaLocation="cnpRecurring_v12.45.xsd"/>
 
     <xs:element name="transaction" type="xp:transactionType" abstract="true"/>
 
@@ -236,10 +236,12 @@
                             <xs:element name="fraudSwitchIndicator" type="xp:fraudSwitchIndicatorEnum" minOccurs="0"/>
                             <xs:element ref="xp:passengerTransportData" minOccurs="0"/>
                             <xs:element name="authIndicator" type="xp:authIndicatorEnum" minOccurs="0"/>
+                            <!--    US2081172-79564-->
+                            <xs:element name="foreignRetailerIndicator" type="xp:foreignRetailerIndicatorEnum" minOccurs="0"/>
                             <xs:element ref="xp:accountFundingTransactionData" minOccurs="0"/>
                             <xs:element name="fraudCheckAction" type="xp:fraudCheckActionEnum" minOccurs="0"/>
                             <!--    US1938960-77433-->
-                            <xs:element name="typeOfDigitalCurrency" type="xp:string5Type" minOccurs="0"/>
+                            <xs:element name="typeOfDigitalCurrency" type="xp:typeOfDigitalCurrencyEnum" minOccurs="0"/>
                             <xs:element name="conversionAffiliateId" type="xp:string15Type" minOccurs="0"/>
                             <xs:element ref="xp:identityBundle" minOccurs="0"/>
                             <xs:element name="originalRetrievalReferenceNumber" type="xp:string12Type" minOccurs="0"/>
@@ -406,7 +408,7 @@
                         <xs:element name="foreignRetailerIndicator" type="xp:foreignRetailerIndicatorEnum" minOccurs="0"/>
                         <xs:element ref="xp:accountFundingTransactionData" minOccurs="0"/>
                         <!--    US1938960-77433-->
-                        <xs:element name="typeOfDigitalCurrency" type="xp:string5Type" minOccurs="0"/>
+                        <xs:element name="typeOfDigitalCurrency" type="xp:typeOfDigitalCurrencyEnum" minOccurs="0"/>
                         <xs:element name="conversionAffiliateId" type="xp:string15Type" minOccurs="0"/>
                     </xs:sequence>
                 </xs:extension>
@@ -491,7 +493,7 @@
                         <xs:element ref="xp:accountFundingTransactionData" minOccurs="0"/>
                         <xs:element name="fraudCheckAction" type="xp:fraudCheckActionEnum" minOccurs="0"/>
                         <!--    US1938960-77433-->
-                        <xs:element name="typeOfDigitalCurrency" type="xp:string5Type" minOccurs="0"/>
+                        <xs:element name="typeOfDigitalCurrency" type="xp:typeOfDigitalCurrencyEnum" minOccurs="0"/>
                         <xs:element name="conversionAffiliateId" type="xp:string15Type" minOccurs="0"/>
                         <xs:element ref="xp:identityBundle" minOccurs="0"/>
                     </xs:sequence>
@@ -2080,7 +2082,7 @@
         <xs:restriction base="xs:string">
             <xs:minLength value="4"/>
             <xs:maxLength value="25"/>
-            <xs:pattern value="[A-Z,a-z,0-9, ,\*,,,\-,',#,&amp;,.]*"/>
+            <xs:pattern value="[A-Za-z0-9 \*,\-'#&amp;.]*"/>
         </xs:restriction>
     </xs:simpleType>
     <xs:simpleType name="customBillingPhoneType">
@@ -2160,7 +2162,7 @@
 
     <xs:simpleType name="ipAddress">
         <xs:restriction base="xs:string">
-            <xs:pattern value="(\d{1,3}.){3}\d{1,3}"/>
+            <xs:pattern value="(\d{1,3}\.){3}\d{1,3}"/>
         </xs:restriction>
     </xs:simpleType>
 

--- a/src/test/java/io/github/vantiv/sdk/TestCnpOnline.java
+++ b/src/test/java/io/github/vantiv/sdk/TestCnpOnline.java
@@ -192,12 +192,14 @@ public class TestCnpOnline {
 		card.setNumber("4100000000000002");
 		card.setExpDate("1210");
 		authorization.setCard(card);
+		authorization.setForeignRetailerIndicator(ForeignRetailerIndicatorEnum.fromValue("A"));
 
 		helperMethodForAuth();
 		cnp.setCommunication(mockedCommunication);
 		AuthorizationResponse authorize = cnp.authorize(authorization);
 		assertEquals(123L, authorize.getCnpTxnId());
 		assertEquals(new BigInteger("1"), authorization.getCardholderAuthentication().getAuthenticationProtocolVersion());
+		assertEquals(ForeignRetailerIndicatorEnum.fromValue("A"), authorization.getForeignRetailerIndicator());
 		assertEquals("sandbox", authorize.getLocation());
 	}
 

--- a/src/test/java/io/github/vantiv/sdk/TestCnpOnline.java
+++ b/src/test/java/io/github/vantiv/sdk/TestCnpOnline.java
@@ -49,6 +49,8 @@ public class TestCnpOnline {
 		card.setNumber("4100000000000002");
 		card.setExpDate("1210");
 		authorization.setCard(card);
+		authorization.setForeignRetailerIndicator(ForeignRetailerIndicatorEnum.fromValue("A"));
+		authorization.setTypeOfDigitalCurrency("7");
 
 		helperMethodForAuth();
 
@@ -278,6 +280,7 @@ public class TestCnpOnline {
 		card.setExpDate("1210");
 		capturegivenauth.setCard(card);
 		helperMethodForCaptureGivenAuth();
+		capturegivenauth.setTypeOfDigitalCurrency("7");
 		cnp.setCommunication(mockedCommunication);
 		CaptureGivenAuthResponse capturegivenauthresponse = cnp.captureGivenAuth(capturegivenauth);
 		assertEquals(123L, capturegivenauthresponse.getCnpTxnId());
@@ -581,6 +584,7 @@ public class TestCnpOnline {
 		card.setNumber("4100000000000002");
 		card.setExpDate("1210");
 		sale.setCard(card);
+		sale.setTypeOfDigitalCurrency("7");
 		helperMethodForSale();
 		cnp.setCommunication(mockedCommunication);
 		SaleResponse saleresponse = cnp.sale(sale);


### PR DESCRIPTION
* Change: [cnpAPI v12.45] In existing enum 'foreignRetailerIndicatorEnum' new values 'A','B'.
* Change: [cnpAPI v12.45] In existing authorization request new element 'foreignRetailerIndicator' of type 'foreignRetailerIndicatorEnum' is added.
* Change: [cnpAPI v12.45] In existing requests 'authorization','sale','captureGivenAuth' type of existing element 'typeOfDigitalCurrency' is changed from string to 'typeOfDigitalCurrencyEnum'.
