### PR TITLE
Sdk upgrade 12.48

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,12 @@
 = Vantiv eCommerce CNP CHANGELOG
 
+==Change Log for 12.48 (October 29,2025)
+* Change: [cnpAPI v12.48] New element pazeEncryptedPayload added to both Auth and Sale transaction requests.
+* Change: [cnpAPI v12.48] New complex element TLID added in authResponse and authReversalResponse.
+* Change: [cnpAPI v12.48] New sub elements to support TLID - lifecycleTlid (type: tlidType),economicTlid (type: tlidType),tlidCustomerProvided (type: tlidType) and tlidValidationActionIndicator (type: tlidValidationActionIndicatorType)
+* Change: [cnpAPI v12.48] New element tlidValidationActionIndicatorType added with Enum values 1, 2.
+* Change: [cnpAPI v12.48] New type tlidType added as string for TLID fields.
+
 ==Change Log for 12.47 (July 28,2025)
 * Change: [cnpAPI v12.47] New header 'X-Ecom-Api' is added in the request on the basis 2 cofiguration newly added properties in the property file 'sendEcomHeader' and 'ecomHeaderValue'.
 * Change: [cnpAPI v12.47] New enum 'numberOfPaymentsEnum' added with values '1','2','3','4','5','6','7','8','9','+' .

--- a/README.md
+++ b/README.md
@@ -144,6 +144,58 @@ public class SampleCnpTxn {
 	}
 }
 ```
+Setting Up OLTP Encryption Functionality
+-----------------------------------------
+To enable OLTP encryption functionality, follow these steps:
+
+1. Add the following properties to your configuration file (.cnp_SDK_config.properties):
+
+    oltpEncryptionPayload (true/false)
+    oltpEncryptionKeySequence (this is received in the response of encryptionKeyRequest)
+    oltpEncryptionKeyPath (path where key is stored)
+
+2. Obtain Encryption Key:
+    
+    Send an encryptionKeyRequest to obtain the encryption key and key sequence.
+
+3. Key Setup:
+
+    Save the encryptionkey in one file.
+    Ensure the key setup is done with the values obtained key sequence and path of the encryptionkey file.
+
+4. Processing OLTP Transactions:
+
+     Run any OLTP transaction. The transaction will be processed based on the value of oltpEncryptionPayload.
+     If oltpEncryptionPayload is set to true, the transaction payload will be converted to an encrypted payload, and a normal cnpOnlineRequest will be formed.
+     The request will be processed to give a plain text/normal response.
+     
+ By following these steps, you can enable and configure OLTP encryption functionality in the cnp-sdk-for-java project.
+
+5. Below are samples for transactions.
+
+Example for encryptionKeyRequest:
+
+```java
+    import com.cnp.sdk.*;
+    import com.cnp.sdk.generate.*;
+    public class SampleEncryptionKeyRequest {
+
+	public static void main(String[] args) {
+
+        EncryptionKeyRequest request = new EncryptionKeyRequest();
+        request.setEncryptionKeyRequest(EncryptionKeyRequestEnum.CURRENT);
+		
+        // Peform the transaction on the Vantiv eCommerce Platform
+        EncryptionKeyResponse response = cnp.encryptionKeyRequest(request.getEncryptionKeyRequest());
+        
+        // display result
+        System.out.println("Key Sequence: " + response.getEncryptionKeySequence());
+        System.out.println("Encryption Key : " + response.getEncryptionKey());
+	}
+    }
+```
+
+There is one example shown in Note section can be used to validate transaction processing  after doing all setup . 
 
 More examples can be found here [Java Gists](https://gist.github.com/VantivSDK)
 

--- a/README.md
+++ b/README.md
@@ -150,9 +150,9 @@ To enable OLTP encryption functionality, follow these steps:
 
 1. Add the following properties to your configuration file (.cnp_SDK_config.properties):
 
-    oltpEncryptionPayload (true/false)
-    oltpEncryptionKeySequence (this is received in the response of encryptionKeyRequest)
-    oltpEncryptionKeyPath (path where key is stored)
+    1. oltpEncryptionPayload (true/false)
+    2. oltpEncryptionKeySequence (this is received in the response of encryptionKeyRequest)
+    3. oltpEncryptionKeyPath (path where key is stored)
 
 2. Obtain Encryption Key:
     

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 DIST_DIR_15=build/dist/java15
-JAR_VERSION=12.47.0
+JAR_VERSION=12.48.0
 KIT_DIR=build/kit/java15
 KIT_DEPENDENCIES_DIR=build/kit/java15/dependencies
 OPENSFTP_DIR=lib/opensftp-0.3.0
-SCHEMA_VERSION=12.47
+SCHEMA_VERSION=12.48

--- a/src/functionalTest/java/io/github/vantiv/sdk/TestAuth.java
+++ b/src/functionalTest/java/io/github/vantiv/sdk/TestAuth.java
@@ -1167,4 +1167,65 @@ public class TestAuth {
 		assertEquals("Approved", response.getMessage());
 		assertEquals("sandbox", response.getLocation());
 	}
+
+	//v12.48 changes to test pazeEncryptedPayload
+	@Test
+	public void authPazePayload_VI_Approve() throws Exception {
+		Authorization authorization = new Authorization();
+		authorization.setReportGroup("Planets");
+		authorization.setOrderId("12344");
+		authorization.setAmount(106L);
+		authorization.setOrderSource(OrderSourceType.ECOMMERCE);
+		authorization.setId("id");
+		authorization.setPazeEncryptedPayload("NDEwMDAwMDAwMDAwMDAwMA==");
+		AuthorizationResponse response = cnp.authorize(authorization);
+		assertEquals(response.getMessage(), "000",response.getResponse());
+		assertEquals("Approved", response.getMessage());
+		assertEquals("sandbox", response.getLocation());
+	}
+
+	@Test
+	public void authPazePayload_VI_Decline() throws Exception {
+		Authorization authorization = new Authorization();
+		authorization.setReportGroup("Planets");
+		authorization.setOrderId("12344");
+		authorization.setAmount(106L);
+		authorization.setOrderSource(OrderSourceType.ECOMMERCE);
+		authorization.setId("id");
+		authorization.setPazeEncryptedPayload("NDEwMDAwMDAwMDAwMDAwMQ==");
+		AuthorizationResponse response = cnp.authorize(authorization);
+		assertEquals(response.getMessage(), "350",response.getResponse());
+		assertEquals("Generic Decline", response.getMessage());
+		assertEquals("sandbox", response.getLocation());
+	}
+
+	@Test
+	public void authPazePayload_MC_Approve() throws Exception {
+		Authorization authorization = new Authorization();
+		authorization.setReportGroup("Planets");
+		authorization.setOrderId("12344");
+		authorization.setAmount(106L);
+		authorization.setOrderSource(OrderSourceType.ECOMMERCE);
+		authorization.setId("id");
+		authorization.setPazeEncryptedPayload("NTEwMDAwMDAwMDAwMDAwMA==");
+		AuthorizationResponse response = cnp.authorize(authorization);
+		assertEquals(response.getMessage(), "000",response.getResponse());
+		assertEquals("Approved", response.getMessage());
+		assertEquals("sandbox", response.getLocation());
+	}
+
+	@Test
+	public void authPazePayload_MC_Decline() throws Exception {
+		Authorization authorization = new Authorization();
+		authorization.setReportGroup("Planets");
+		authorization.setOrderId("12344");
+		authorization.setAmount(106L);
+		authorization.setOrderSource(OrderSourceType.ECOMMERCE);
+		authorization.setId("id");
+		authorization.setPazeEncryptedPayload("NTEwMDAwMDAwMDAwMDAwMQ==");
+		AuthorizationResponse response = cnp.authorize(authorization);
+		assertEquals(response.getMessage(), "350",response.getResponse());
+		assertEquals("Generic Decline", response.getMessage());
+		assertEquals("sandbox", response.getLocation());
+	}
 }

--- a/src/functionalTest/java/io/github/vantiv/sdk/TestBatchFile.java
+++ b/src/functionalTest/java/io/github/vantiv/sdk/TestBatchFile.java
@@ -1227,6 +1227,25 @@ public class TestBatchFile {
         saleReq.setId("id");
         batch.addTransaction(saleReq);
 
+        //Changes to test v12.48 -pazeEncryptedPayload in auth and sale txn request
+        Authorization authorization = new Authorization();
+        authorization.setReportGroup("Planets");
+        authorization.setOrderId("12344");
+        authorization.setAmount(106L);
+        authorization.setOrderSource(OrderSourceType.ECOMMERCE);
+        authorization.setId("id");
+        authorization.setPazeEncryptedPayload("NTEwMDAwMDAwMDAwMDAw");
+        batch.addTransaction(authorization);
+
+        Sale sale = new Sale();
+        sale.setReportGroup("Planets");
+        sale.setOrderId("12344");
+        sale.setAmount(106L);
+        sale.setOrderSource(OrderSourceType.ECOMMERCE);
+        sale.setId("id");
+        sale.setPazeEncryptedPayload("NTEwMDAwMDAwMDAwMDAwMA==");
+        batch.addTransaction(sale);
+
         int transactionCount = batch.getNumberOfTransactions();
 
         CnpBatchFileResponse fileResponse = request.sendToCnpSFTP();

--- a/src/main/java/io/github/vantiv/sdk/TlidValidationActionIndicatorType.java
+++ b/src/main/java/io/github/vantiv/sdk/TlidValidationActionIndicatorType.java
@@ -1,0 +1,34 @@
+package io.github.vantiv.sdk;
+
+import javax.xml.bind.annotation.XmlEnum;
+import javax.xml.bind.annotation.XmlEnumValue;
+import javax.xml.bind.annotation.XmlType;
+
+@XmlType(name = "tlidValidationActionIndicatorType")
+@XmlEnum(Integer.class)
+public enum TlidValidationActionIndicatorType {
+
+    @XmlEnumValue("1")
+    ONE(1),
+    @XmlEnumValue("2")
+    TWO(2);
+
+    private final int value;
+
+    TlidValidationActionIndicatorType(int value) {
+        this.value = value;
+    }
+
+    public int getValue() {
+        return value;
+    }
+
+    public static TlidValidationActionIndicatorType fromValue(int value) {
+        for (TlidValidationActionIndicatorType enumValue : TlidValidationActionIndicatorType.values()) {
+            if (enumValue.value == value) {
+                return enumValue;
+            }
+        }
+        throw new IllegalArgumentException("Invalid value: " + value);
+    }
+}

--- a/src/main/java/io/github/vantiv/sdk/Versions.java
+++ b/src/main/java/io/github/vantiv/sdk/Versions.java
@@ -2,6 +2,6 @@ package io.github.vantiv.sdk;
 
 public class Versions {
 
-    public static final String XML_VERSION = "12.47";
-    public static final String SDK_VERSION = "Java;12.47.0";
+    public static final String XML_VERSION = "12.48";
+    public static final String SDK_VERSION = "Java;12.48.0";
 }

--- a/src/main/xsd/cnpBatch_v12.48.xsd
+++ b/src/main/xsd/cnpBatch_v12.48.xsd
@@ -2,7 +2,7 @@
 <xs:schema targetNamespace="http://www.vantivcnp.com/schema" xmlns:xs="http://www.w3.org/2001/XMLSchema"
            xmlns:xp="http://www.vantivcnp.com/schema" elementFormDefault="qualified" attributeFormDefault="unqualified">
 
-    <xs:include schemaLocation="cnpTransaction_v12.47.xsd" />
+    <xs:include schemaLocation="cnpTransaction_v12.48.xsd" />
 
     <xs:element name="cnpRequest">
         <xs:complexType>

--- a/src/main/xsd/cnpCommon_v12.48.xsd
+++ b/src/main/xsd/cnpCommon_v12.48.xsd
@@ -242,6 +242,13 @@
         </xs:restriction>
     </xs:simpleType>
 
+    <xs:simpleType name="stringTypeForPazeEncryptedPayload">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="7500" />
+        </xs:restriction>
+    </xs:simpleType>
+
+
     <xs:simpleType name="methodOfPaymentTypeEnum">
         <xs:restriction base="xs:string">
             <xs:enumeration value="MC" />

--- a/src/main/xsd/cnpOnline_v12.48.xsd
+++ b/src/main/xsd/cnpOnline_v12.48.xsd
@@ -3,7 +3,7 @@
 <xs:schema targetNamespace="http://www.vantivcnp.com/schema" xmlns:xp="http://www.vantivcnp.com/schema"
            xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="unqualified">
 
-    <xs:include schemaLocation="cnpTransaction_v12.47.xsd" />
+    <xs:include schemaLocation="cnpTransaction_v12.48.xsd" />
 
     <xs:complexType name="baseRequest">
         <xs:sequence>
@@ -311,7 +311,7 @@
         </xs:complexType>
     </xs:element>
 
-  <!--  <xs:element name="vendorCredit" substitutionGroup="xp:transaction">
+   <!-- <xs:element name="vendorCredit" substitutionGroup="xp:transaction">
         <xs:complexType>
             <xs:complexContent>
                 <xs:extension base="xp:transactionTypeWithReportGroup">

--- a/src/main/xsd/cnpRecurring_v12.48.xsd
+++ b/src/main/xsd/cnpRecurring_v12.48.xsd
@@ -1,7 +1,7 @@
 <xs:schema targetNamespace="http://www.vantivcnp.com/schema" xmlns:xp="http://www.vantivcnp.com/schema"
            xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="unqualified">
 
-    <xs:include schemaLocation="cnpCommon_v12.47.xsd" />
+    <xs:include schemaLocation="cnpCommon_v12.48.xsd" />
 
     <xs:element name="recurringTransaction" type="xp:recurringTransactionType" abstract="true" />
     <xs:element name="recurringTransactionResponse" type="xp:recurringTransactionResponseType" abstract="true" />

--- a/src/main/xsd/cnpTransaction_v12.48.xsd
+++ b/src/main/xsd/cnpTransaction_v12.48.xsd
@@ -2,8 +2,8 @@
            xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified"
            attributeFormDefault="unqualified">
 
-    <xs:include schemaLocation="cnpCommon_v12.47.xsd"/>
-    <xs:include schemaLocation="cnpRecurring_v12.47.xsd"/>
+    <xs:include schemaLocation="cnpCommon_v12.48.xsd"/>
+    <xs:include schemaLocation="cnpRecurring_v12.48.xsd"/>
 
     <xs:element name="transaction" type="xp:transactionType" abstract="true"/>
 
@@ -200,6 +200,7 @@
                                 <xs:element name="token" type="xp:cardTokenType"/>
                                 <xs:element name="paypage" type="xp:cardPaypageType"/>
                                 <xs:element name="applepay" type="xp:applepayType"/>
+                                <xs:element name="pazeEncryptedPayload" type="xp:stringTypeForPazeEncryptedPayload"/>
                             </xs:choice>
                             <xs:element name="cardholderAuthentication" type="xp:fraudCheckType" minOccurs="0"/>
                             <xs:element ref="xp:processingInstructions" minOccurs="0"/>
@@ -445,6 +446,7 @@
                             <xs:element name="ideal" type="xp:idealType"/>
                             <xs:element name="giropay" type="xp:giropayType"/>
                             <xs:element name="sofort" type="xp:sofortType"/>
+                            <xs:element name="pazeEncryptedPayload" type="xp:stringTypeForPazeEncryptedPayload"/>
                         </xs:choice>
                         <!-- fraudCheck is not used in the mapping -->
 
@@ -981,6 +983,7 @@
                         <xs:element name="fundingTransactionReferenceNumber" type="xp:string19Type" minOccurs="0"/>
                         <xs:element name="retrievalReferenceNumber" type="xp:string12Type" minOccurs="0"/>
                         <xs:element name="orderSource" type="xp:orderSourceType" minOccurs="0"/>
+                        <xs:element ref="xp:tlid" minOccurs="0"/>
                     </xs:all>
                 </xs:extension>
             </xs:complexContent>
@@ -1158,6 +1161,7 @@
                         <xs:element ref="xp:pinlessDebitResponse" minOccurs="0"/>
                         <!-- Introduced as part of Guaranteed Payments -->
                         <xs:element name="checkoutId" type="xp:string256Type" minOccurs="0"/>
+                        <xs:element ref="xp:tlid" minOccurs="0"/>
                     </xs:all>
                 </xs:extension>
             </xs:complexContent>
@@ -2032,6 +2036,18 @@
             <xs:enumeration value="7"/>
             <xs:enumeration value="8"/>
             <xs:enumeration value="9"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="tlidValidationActionIndicatorType">
+        <xs:restriction base="xs:integer">
+            <xs:enumeration value="1"/>
+            <xs:enumeration value="2"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="tlidType">
+        <xs:restriction base="xs:string">
+            <xs:maxLength value="22"/>
         </xs:restriction>
     </xs:simpleType>
 
@@ -3316,6 +3332,17 @@
                 <xs:element name="networkToken" type="xp:ccAccountNumberType" minOccurs="0"/>
                 <xs:element name="authMaxResponseCode" type="xp:responseType" minOccurs="0"/>
                 <xs:element name="authMaxResponseMessage" type="xp:messageType" minOccurs="0"/>
+            </xs:all>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="tlid">
+        <xs:complexType>
+            <xs:all>
+                <xs:element name="lifecycleTlid" type="xp:tlidType" minOccurs="0"/>
+                <xs:element name="economicTlid" type="xp:tlidType" minOccurs="0"/>
+                <xs:element name="tlidValidationActionIndicator" type="xp:tlidValidationActionIndicatorType" minOccurs="0"/>
+                <xs:element name="tlidCustomerProvided" type="xp:tlidType" minOccurs="0"/>
             </xs:all>
         </xs:complexType>
     </xs:element>


### PR DESCRIPTION
Change: [cnpAPI v12.48] New element pazeEncryptedPayload added to both Auth and Sale transaction requests.
Change: [cnpAPI v12.48] New complex element TLID added in authResponse and authReversalResponse.
Change: [cnpAPI v12.48] New sub elements to support TLID - lifecycleTlid (type: tlidType),economicTlid (type: tlidType),tlidCustomerProvided (type: tlidType) and tlidValidationActionIndicator (type: tlidValidationActionIndicatorType).
Change: [cnpAPI v12.48] New element tlidValidationActionIndicatorType added with Enum values 1, 2.
Change: [cnpAPI v12.48] New type tlidType added as string for TLID fields.
